### PR TITLE
Add instructor sub-roles

### DIFF
--- a/src/lti/LTI_Constants.php
+++ b/src/lti/LTI_Constants.php
@@ -74,4 +74,34 @@ class LTI_Constants
     public const COURSE_OFFERING = 'http://purl.imsglobal.org/vocab/lis/v2/course#CourseOffering';
     public const COURSE_SECTION = 'http://purl.imsglobal.org/vocab/lis/v2/course#CourseSection';
     public const COURSE_GROUP = 'http://purl.imsglobal.org/vocab/lis/v2/course#Group';
+
+    // Context sub-roles
+    public const SUB_ADMINISTRATOR = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Administrator#Administrator';
+    public const SUB_DEVELOPER = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Administrator#Developer';
+    public const SUB_EXTERNALDEVELOPER = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Administrator#ExternalDeveloper';
+    public const SUB_EXTERNALSUPPORT = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Administrator#ExternalSupport';
+    public const SUB_EXTERNALSYSTEMADMINISTRATOR = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Administrator#ExternalSystemAdministrator';
+    public const SUB_SUPPORT = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Administrator#Support';
+    public const SUB_SYSTEMADMINISTRATOR = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Administrator#SystemAdministrator';
+    public const SUB_CONTENTDEVELOPER = 'http://purl.imsglobal.org/vocab/lis/v2/membership/ContentDeveloper#ContentDeveloper';
+    public const SUB_CONTENTEXPERT = 'http://purl.imsglobal.org/vocab/lis/v2/membership/ContentDeveloper#ContentExpert';
+    public const SUB_EXTERNALCONTENTEXPERT = 'http://purl.imsglobal.org/vocab/lis/v2/membership/ContentDeveloper#ExternalContentExpert';
+    public const SUB_LIBRARIAN = 'http://purl.imsglobal.org/vocab/lis/v2/membership/ContentDeveloper#Librarian';
+    public const SUB_EXTERNALINSTRUCTOR = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#ExternalInstructor';
+    public const SUB_GRADER = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#Grader';
+    public const SUB_GUESTINSTRUCTOR = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#GuestInstructor';
+    public const SUB_LECTURER = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#Lecturer';
+    public const SUB_PRIMARYINSTRUCTOR = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#PrimaryInstructor';
+    public const SUB_SECONDARYINSTRUCTOR = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#SecondaryInstructor';
+    public const SUB_TA = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#TeachingAssistant';
+    public const SUB_TAGROUP = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#TeachingAssistantGroup';
+    public const SUB_TAOFFERING = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#TeachingAssistantOffering';
+    public const SUB_TASECTION = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#TeachingAssistantSection';
+    public const SUB_TASECTIONASSOCIATION = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#TeachingAssistantSectionAssociation';
+    public const SUB_TATEMPLATE = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#TeachingAssistantTemplate';
+    public const SUB_EXTERNALLEARNER = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Learner#ExternalLearner';
+    public const SUB_GUESTLEARNER = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Learner#GuestLearner';
+    public const SUB_INSTRUCTOR = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Learner#Instructor';
+    public const SUB_LEARNER = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Learner#Learner';
+    public const SUB_NONCREDITLEARNER = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Learner#NonCreditLearner';
 }

--- a/src/lti/LTI_Constants.php
+++ b/src/lti/LTI_Constants.php
@@ -76,17 +76,6 @@ class LTI_Constants
     public const COURSE_GROUP = 'http://purl.imsglobal.org/vocab/lis/v2/course#Group';
 
     // Context sub-roles
-    public const SUB_ADMINISTRATOR = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Administrator#Administrator';
-    public const SUB_DEVELOPER = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Administrator#Developer';
-    public const SUB_EXTERNALDEVELOPER = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Administrator#ExternalDeveloper';
-    public const SUB_EXTERNALSUPPORT = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Administrator#ExternalSupport';
-    public const SUB_EXTERNALSYSTEMADMINISTRATOR = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Administrator#ExternalSystemAdministrator';
-    public const SUB_SUPPORT = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Administrator#Support';
-    public const SUB_SYSTEMADMINISTRATOR = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Administrator#SystemAdministrator';
-    public const SUB_CONTENTDEVELOPER = 'http://purl.imsglobal.org/vocab/lis/v2/membership/ContentDeveloper#ContentDeveloper';
-    public const SUB_CONTENTEXPERT = 'http://purl.imsglobal.org/vocab/lis/v2/membership/ContentDeveloper#ContentExpert';
-    public const SUB_EXTERNALCONTENTEXPERT = 'http://purl.imsglobal.org/vocab/lis/v2/membership/ContentDeveloper#ExternalContentExpert';
-    public const SUB_LIBRARIAN = 'http://purl.imsglobal.org/vocab/lis/v2/membership/ContentDeveloper#Librarian';
     public const SUB_EXTERNALINSTRUCTOR = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#ExternalInstructor';
     public const SUB_GRADER = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#Grader';
     public const SUB_GUESTINSTRUCTOR = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#GuestInstructor';
@@ -99,9 +88,4 @@ class LTI_Constants
     public const SUB_TASECTION = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#TeachingAssistantSection';
     public const SUB_TASECTIONASSOCIATION = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#TeachingAssistantSectionAssociation';
     public const SUB_TATEMPLATE = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#TeachingAssistantTemplate';
-    public const SUB_EXTERNALLEARNER = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Learner#ExternalLearner';
-    public const SUB_GUESTLEARNER = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Learner#GuestLearner';
-    public const SUB_INSTRUCTOR = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Learner#Instructor';
-    public const SUB_LEARNER = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Learner#Learner';
-    public const SUB_NONCREDITLEARNER = 'http://purl.imsglobal.org/vocab/lis/v2/membership/Learner#NonCreditLearner';
 }


### PR DESCRIPTION
This PR adds some constants for the instructor sub-roles, as per the [IMS 1.3 spec](http://www.imsglobal.org/spec/lti/v1p3/#context-sub-roles). I didn't write any automated tests since these are just constants, but I manually verified that all of the URLs were the format `http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#{sub-rolename}` and that the string after `SUB_` matched the rolename at the end of each URL. Although there are additional sub-roles, I only included the instructor sub-roles to minimize the scope of this PR.