### PR TITLE
Add canvas extension to LtiGrade

### DIFF
--- a/src/LtiGrade.php
+++ b/src/LtiGrade.php
@@ -22,6 +22,7 @@ class LtiGrade
         $this->timestamp = $grade['timestamp'] ?? null;
         $this->user_id = $grade['userId'] ?? null;
         $this->submission_review = $grade['submissionReview'] ?? null;
+        $this->canvasExtension = $grade['https://canvas.instructure.com/lti/submission'] ?? null;
     }
 
     /**
@@ -119,6 +120,15 @@ class LtiGrade
         return $this;
     }
 
+    // Custom Extension for Canvas. Currently this will only add the
+    // submitted_at param.
+    // https://documentation.instructure.com/doc/api/score.html
+    public function setCanvasExtension($value)
+    {
+        $this->canvasExtension = ['submitted_at' => $value];
+        return $this;
+    }
+
     public function __toString()
     {
         return json_encode(array_filter([
@@ -130,6 +140,7 @@ class LtiGrade
             'timestamp' => $this->timestamp,
             'userId' => $this->user_id,
             'submissionReview' => $this->submission_review,
+            'https://canvas.instructure.com/lti/submission' => $this->canvasExtension
         ]));
     }
 }

--- a/src/LtiGrade.php
+++ b/src/LtiGrade.php
@@ -22,7 +22,7 @@ class LtiGrade
         $this->timestamp = $grade['timestamp'] ?? null;
         $this->user_id = $grade['userId'] ?? null;
         $this->submission_review = $grade['submissionReview'] ?? null;
-        $this->canvasExtension = $grade['https://canvas.instructure.com/lti/submission'] ?? null;
+        $this->canvas_extension = $grade['https://canvas.instructure.com/lti/submission'] ?? null;
     }
 
     /**
@@ -120,12 +120,16 @@ class LtiGrade
         return $this;
     }
 
-    // Custom Extension for Canvas. Currently this will only add the
-    // submitted_at param.
+    public function getCanvasExtension()
+    {
+        return $this->canvas_extension;
+    }
+
+    // Custom Extension for Canvas.
     // https://documentation.instructure.com/doc/api/score.html
     public function setCanvasExtension($value)
     {
-        $this->canvasExtension = ['submitted_at' => $value];
+        $this->canvas_extension = $value;
         return $this;
     }
 
@@ -140,7 +144,7 @@ class LtiGrade
             'timestamp' => $this->timestamp,
             'userId' => $this->user_id,
             'submissionReview' => $this->submission_review,
-            'https://canvas.instructure.com/lti/submission' => $this->canvasExtension
+            'https://canvas.instructure.com/lti/submission' => $this->canvas_extension
         ]));
     }
 }

--- a/tests/LtiGradeTest.php
+++ b/tests/LtiGradeTest.php
@@ -205,6 +205,7 @@ class LtiGradeTest extends TestCase
             'timestamp' => 'Timestamp',
             'userId' => 'UserId',
             'submissionReview' => 'SubmissionReview',
+            'https://canvas.instructure.com/lti/submission' => 'CanvasExtension'
         ];
 
         $grade = new LtiGrade($expected);

--- a/tests/LtiGradeTest.php
+++ b/tests/LtiGradeTest.php
@@ -175,6 +175,25 @@ class LtiGradeTest extends TestCase
         $this->assertEquals($expected, $this->grade->getSubmissionReview());
     }
 
+    public function testItGetsCanvasExtension()
+    {
+        $expected = 'expected';
+        $grade = new LtiGrade([ 'https://canvas.instructure.com/lti/submission' => $expected ]);
+
+        $result = $grade->getCanvasExtension();
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testItSetsCanvasExtension()
+    {
+        $expected = 'expected';
+
+        $this->grade->setCanvasExtension($expected);
+
+        $this->assertEquals($expected, $this->grade->getCanvasExtension());
+    }
+
     public function testItCastsFullObjectToString()
     {
         $expected = [


### PR DESCRIPTION
Canvas has a custom extension to send the submitted_at date of a grade so that submissions don't get marked as late in Canvas when they're sent past a due date.

See IMS Spec on extensions: http://www.imsglobal.org/spec/lti-ags/v2p0#extensions

I have tested these changes on a locally running version of PBQ and Canvas.

ETA: This param *should* be ignored when passing a grade to LMSes other than Canvas. I cannot test this locally however, and will need to wait to test it on dev.