### PR TITLE
DEV-11264: Add timeout to LtiServiceConnector

### DIFF
--- a/src/LtiServiceConnector.php
+++ b/src/LtiServiceConnector.php
@@ -78,6 +78,7 @@ class LtiServiceConnector implements LtiServiceConnectorInterface
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_HEADER, 1);
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 60);
         if ($method === 'POST') {
             curl_setopt($ch, CURLOPT_POST, 1);
             curl_setopt($ch, CURLOPT_POSTFIELDS, strval($body));

--- a/src/LtiServiceConnector.php
+++ b/src/LtiServiceConnector.php
@@ -78,7 +78,7 @@ class LtiServiceConnector implements LtiServiceConnectorInterface
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_HEADER, 1);
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 60);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 60);
         if ($method === 'POST') {
             curl_setopt($ch, CURLOPT_POST, 1);
             curl_setopt($ch, CURLOPT_POSTFIELDS, strval($body));


### PR DESCRIPTION
Adds a 60 second timeout to curl request using [CURLOPT_TIMEOUT](https://curl.se/libcurl/c/CURLOPT_TIMEOUT.html)

There seems to be different timeout types for curl. For example 
1. [CURLOPT_CONNECTTIMEOUT](https://curl.se/libcurl/c/CURLOPT_CONNECTTIMEOUT.html): Number of seconds allotted for the request to connect to the server.
2. [CURLOPT_TIMEOUT](https://curl.se/libcurl/c/CURLOPT_TIMEOUT.html): Number of seconds allotted for the entire request to finish. 

~I chose 1 because it seems like that's where we wanted the timeout to happen, but if it's not happy to make the change.~
Chose 2 cause that's what Guzzle uses. 

<details>
<summary>Test Pass:</summary>

![Screenshot from 2021-05-06 14-03-37](https://user-images.githubusercontent.com/8699045/117366276-5d05cd00-ae75-11eb-93cd-74ecac2b1270.png)

</details>
