### PR TITLE
Add 'text' parameter to Deep Link resources

### DIFF
--- a/src/LtiDeepLinkResource.php
+++ b/src/LtiDeepLinkResource.php
@@ -6,6 +6,7 @@ class LtiDeepLinkResource
 
     private $type = 'ltiResourceLink';
     private $title;
+    private $text;
     private $url;
     private $lineitem;
     private $custom_params = [];
@@ -34,6 +35,17 @@ class LtiDeepLinkResource
     public function setTitle($value)
     {
         $this->title = $value;
+        return $this;
+    }
+
+    public function getText()
+    {
+        return $this->text;
+    }
+
+    public function setText($value)
+    {
+        $this->text = $value;
         return $this;
     }
 
@@ -86,6 +98,7 @@ class LtiDeepLinkResource
         $resource = [
             "type" => $this->type,
             "title" => $this->title,
+            "text" => $this->text,
             "url" => $this->url,
             "presentation" => [
                 "documentTarget" => $this->target,

--- a/tests/LtiDeepLinkResourceTest.php
+++ b/tests/LtiDeepLinkResourceTest.php
@@ -57,6 +57,22 @@ class LtiDeepLinkResourceTest extends TestCase
         $this->assertEquals($expected, $this->deepLinkResource->getTitle());
     }
 
+    public function testItGetsText()
+    {
+        $result = $this->deepLinkResource->getText();
+
+        $this->assertNull($result);
+    }
+
+    public function testItSetsText()
+    {
+        $expected = 'expected';
+
+        $this->deepLinkResource->setText($expected);
+
+        $this->assertEquals($expected, $this->deepLinkResource->getText());
+    }
+
     public function testItGetsUrl()
     {
         $result = $this->deepLinkResource->getUrl();
@@ -126,6 +142,7 @@ class LtiDeepLinkResourceTest extends TestCase
         $expected = [
             "type" => 'ltiResourceLink',
             "title" => 'a_title',
+            "text" => 'a_text',
             "url" => 'a_url',
             "presentation" => [
                 "documentTarget" => 'iframe',
@@ -143,6 +160,7 @@ class LtiDeepLinkResourceTest extends TestCase
             ->once()->andReturn($expected['lineItem']['label']);
 
         $this->deepLinkResource->setTitle($expected['title']);
+        $this->deepLinkResource->setText($expected['text']);
         $this->deepLinkResource->setUrl($expected['url']);
         $this->deepLinkResource->setLineitem($lineitem);
 


### PR DESCRIPTION
The [LTI Deep Linking Specification](https://www.imsglobal.org/spec/lti-dl/v2p0#content-item-types) defines an optional parameter "text" for all core content item types. This "text" parameter is a plain description of the content item being defined, beyond title.

This PR adds support for this "text" parameter.