### PR TITLE
Enables dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This PR is the result of clicking "enable dependabot" in the repo settings and then filling in the value `composer` for the package-ecosystem (https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#package-ecosystem)

## Summary of Changes

<!-- A few sentences describing the big picture of your changes. -->

## Testing

<!-- Describe how this PR has been tested, manually and automatically. -->

- [X] I have run `composer test`
- [X] I have run `composer lint-fix`
