### PR TITLE
DATAINF-97 Change how POST requests are made to fix double-encoded JSON

### DIFF
--- a/src/Interfaces/ILtiServiceConnector.php
+++ b/src/Interfaces/ILtiServiceConnector.php
@@ -6,5 +6,5 @@ interface ILtiServiceConnector
 {
     public function getAccessToken(array $scopes);
 
-    public function makeServiceRequest(array $scopes, $method, $url, $body = null, $contentType = 'application/json', $accept = 'application/json');
+    public function makeServiceRequest(array $scopes, string $method, string $url, string $body = null, $contentType = 'application/json', $accept = 'application/json');
 }

--- a/src/LtiServiceConnector.php
+++ b/src/LtiServiceConnector.php
@@ -75,7 +75,7 @@ class LtiServiceConnector implements ILtiServiceConnector
         return $tokenData['access_token'];
     }
 
-    public function makeServiceRequest(array $scopes, $method, $url, $body = null, $contentType = 'application/json', $accept = 'application/json')
+    public function makeServiceRequest(array $scopes, string $method, string $url, string $body = null, $contentType = 'application/json', $accept = 'application/json')
     {
         $headers = [
             'Authorization' => 'Bearer '.$this->getAccessToken($scopes),
@@ -87,7 +87,7 @@ class LtiServiceConnector implements ILtiServiceConnector
                 $headers = array_merge($headers, ['Content-Type' => $contentType]);
                 $response = $this->client->request($method, $url, [
                     'headers' => $headers,
-                    'json' => $body,
+                    'body' => $body,
                 ]);
                 break;
             default:
@@ -98,10 +98,13 @@ class LtiServiceConnector implements ILtiServiceConnector
         }
 
         $respHeaders = $response->getHeaders();
+        array_walk($respHeaders, function (&$value) {
+            $value = $value[0];
+        });
         $respBody = $response->getBody();
 
         return [
-            'headers' => array_filter(explode("\r\n", $respHeaders)),
+            'headers' => $respHeaders,
             'body' => json_decode($respBody, true),
         ];
     }

--- a/tests/LtiServiceConnectorTest.php
+++ b/tests/LtiServiceConnectorTest.php
@@ -13,6 +13,31 @@ use Psr\Http\Message\ResponseInterface;
 
 class LtiServiceConnectorTest extends TestCase
 {
+    /**
+     * @var Mockery\MockInterface
+     */
+    private $registration;
+    /**
+     * @var Mockery\MockInterface
+     */
+    private $cache;
+    /**
+     * @var Mockery\MockInterface
+     */
+    private $client;
+    /**
+     * @var Mockery\MockInterface
+     */
+    private $response;
+    /**
+     * @var string
+     */
+    private $token;
+    /**
+     * @var LtiServiceConnector
+     */
+    private $connector;
+
     public function setUp(): void
     {
         $this->registration = Mockery::mock(ILtiRegistration::class);
@@ -69,19 +94,22 @@ class LtiServiceConnectorTest extends TestCase
         $scopes = ['scopeKey'];
         $method = 'post';
         $url = 'https://example.com';
-        $body = ['post' => 'body'];
+        $body = json_encode(['post' => 'body']);
         $requestHeaders = [
             'Authorization' => 'Bearer '.$this->token,
             'Accept' => 'application/json',
             'Content-Type' => 'application/json',
         ];
         $responseHeaders = [
-            'Content-Type: application/json',
-            'Accept: application/json',
+            'Content-Type' => ['application/json'],
+            'Server' => ['nginx'],
         ];
         $responseBody = ['some' => 'response'];
         $expected = [
-            'headers' => $responseHeaders,
+            'headers' => [
+                'Content-Type' => 'application/json',
+                'Server' => 'nginx',
+            ],
             'body' => $responseBody,
         ];
 
@@ -89,10 +117,10 @@ class LtiServiceConnectorTest extends TestCase
         $this->client->shouldReceive('request')
             ->with($method, $url, [
                 'headers' => $requestHeaders,
-                'json' => $body,
+                'body' => $body,
             ])->once()->andReturn($this->response);
         $this->response->shouldReceive('getHeaders')
-            ->once()->andReturn(implode("\r\n", $responseHeaders));
+            ->once()->andReturn($responseHeaders);
         $this->response->shouldReceive('getBody')
             ->once()->andReturn(json_encode($responseBody));
 
@@ -111,12 +139,15 @@ class LtiServiceConnectorTest extends TestCase
             'Accept' => 'application/json',
         ];
         $responseHeaders = [
-            'Content-Type: application/json',
-            'Accept: application/json',
+            'Content-Type' => ['application/json'],
+            'Server' => ['nginx'],
         ];
         $responseBody = ['some' => 'response'];
         $expected = [
-            'headers' => $responseHeaders,
+            'headers' => [
+                'Content-Type' => 'application/json',
+                'Server' => 'nginx',
+            ],
             'body' => $responseBody,
         ];
 
@@ -126,7 +157,7 @@ class LtiServiceConnectorTest extends TestCase
                 'headers' => $requestHeaders,
             ])->once()->andReturn($this->response);
         $this->response->shouldReceive('getHeaders')
-            ->once()->andReturn(implode("\r\n", $responseHeaders));
+            ->once()->andReturn($responseHeaders);
         $this->response->shouldReceive('getBody')
             ->once()->andReturn(json_encode($responseBody));
 


### PR DESCRIPTION
## Summary of Changes

Previously, when we tried to write a new lineitem and grade to an LMS with the makeServiceRequest, Guzzle was making the request which had the body as a string of JSON within quotes (`"{\"score\": 100}"`). This is because the Grade and LineItem __toString functions were encoding the body as JSON, and then we passed that into Guzzle in the `json` key, which then did a second `json_encode()`.

This PR fixes this by instead using the `body` key so the body data is passed as-is. I'm also making the arguments to this `makeServiceRequest()` method more clear to indicate the body is a string. Finally, I'm turning the headers array from Guzzle into a set of key-value pairs (by taking the first header), instead of each header key corresponding to an array of header values (`'header' => ['header value']`)

## Testing

I tested this library with Canvas and verified that a grade was able to be sent back properly.

- [x] I have run `composer test`
- [x] I have run `composer lint-fix`
