### PR TITLE
DEV-11392: fix and add ability to get ALL lineItems in a container

### DIFF
--- a/src/LtiAssignmentsGradesService.php
+++ b/src/LtiAssignmentsGradesService.php
@@ -50,11 +50,6 @@ class LtiAssignmentsGradesService
     {
         $line_items = $this->getLineItems();
 
-        // If there is only one item, then wrap it in an array so the foreach works
-        if (isset($line_items['body']['id'])) {
-            $line_items['body'] = [$line_items['body']];
-        }
-
         foreach ($line_items as $line_item) {
             if (
                 (empty($new_line_item->getResourceId()) && empty($new_line_item->getResourceLinkId())) ||

--- a/src/LtiAssignmentsGradesService.php
+++ b/src/LtiAssignmentsGradesService.php
@@ -70,7 +70,6 @@ class LtiAssignmentsGradesService
             $link = $page['headers']['Link'];
             if (preg_match(LtiServiceConnector::NEXT_PAGE_REGEX, $link, $matches)) {
                 $next_page = $matches[1];
-                dump($next_page);
             }
         }
 

--- a/src/LtiAssignmentsGradesService.php
+++ b/src/LtiAssignmentsGradesService.php
@@ -128,6 +128,7 @@ class LtiAssignmentsGradesService
         if (isset($line_items['body']['id'])) {
             $line_items['body'] = [$line_items['body']];
         }
+
         return $line_items;
     }
 }

--- a/src/LtiAssignmentsGradesService.php
+++ b/src/LtiAssignmentsGradesService.php
@@ -51,19 +51,36 @@ class LtiAssignmentsGradesService
         if (!in_array(LtiConstants::AGS_SCOPE_LINEITEM, $this->service_data['scope'])) {
             throw new LtiException('Missing required scope', 1);
         }
-        $line_items = $this->service_connector->makeServiceRequest(
-            $this->service_data['scope'],
-            LtiServiceConnector::METHOD_GET,
-            $this->service_data['lineitems'],
-            null,
-            null,
-            'application/vnd.ims.lis.v2.lineitemcontainer+json'
-        );
+        $line_items = [];
+
+        $next_page = $this->service_data['lineitems'];
+
+        while ($next_page) {
+            $page = $this->service_connector->makeServiceRequest(
+                $this->service_data['scope'],
+                LtiServiceConnector::METHOD_GET,
+                $next_page,
+                null,
+                null,
+                'application/vnd.ims.lti-gs.v1.contextgroupcontainer+json'
+            );
+
+            $line_items = array_merge($line_items, $page['body']);
+            $next_page = false;
+            $link = $page['headers']['Link'];
+
+            if (preg_match(LtiServiceConnector::NEXT_PAGE_REGEX, $link, $matches)) {
+                $next_page = $matches[1];
+                dump($next_page);
+            }
+        }
+
         // If there is only one item, then wrap it in an array so the foreach works
         if (isset($line_items['body']['id'])) {
             $line_items['body'] = [$line_items['body']];
         }
-        foreach ($line_items['body'] as $line_item) {
+
+        foreach ($line_items as $line_item) {
             if (
                 (empty($new_line_item->getResourceId()) && empty($new_line_item->getResourceLinkId())) ||
                 (isset($line_item['resourceId']) && $line_item['resourceId'] == $new_line_item->getResourceId()) ||
@@ -102,5 +119,40 @@ class LtiAssignmentsGradesService
         );
 
         return $scores['body'];
+    }
+
+    public function getLineItems()
+    {
+        if (!in_array(LtiConstants::AGS_SCOPE_LINEITEM, $this->service_data['scope'])) {
+            throw new LtiException('Missing required scope', 1);
+        }
+        $line_items = [];
+
+        $next_page = $this->service_data['lineitems'];
+
+        while ($next_page) {
+            $page = $this->service_connector->makeServiceRequest(
+                $this->service_data['scope'],
+                LtiServiceConnector::METHOD_GET,
+                $next_page,
+                null,
+                null,
+                'application/vnd.ims.lti-gs.v1.contextgroupcontainer+json'
+            );
+
+            $line_items = array_merge($line_items, $page['body']);
+            $next_page = false;
+            $link = $page['headers']['Link'];
+
+            if (preg_match(LtiServiceConnector::NEXT_PAGE_REGEX, $link, $matches)) {
+                $next_page = $matches[1];
+            }
+        }
+
+        // If there is only one item, then wrap it in an array so the foreach works
+        if (isset($line_items['body']['id'])) {
+            $line_items['body'] = [$line_items['body']];
+        }
+        return $line_items;
     }
 }

--- a/src/LtiAssignmentsGradesService.php
+++ b/src/LtiAssignmentsGradesService.php
@@ -48,30 +48,7 @@ class LtiAssignmentsGradesService
 
     public function findOrCreateLineitem(LtiLineitem $new_line_item)
     {
-        if (!in_array(LtiConstants::AGS_SCOPE_LINEITEM, $this->service_data['scope'])) {
-            throw new LtiException('Missing required scope', 1);
-        }
-        $line_items = [];
-
-        $next_page = $this->service_data['lineitems'];
-
-        while ($next_page) {
-            $page = $this->service_connector->makeServiceRequest(
-                $this->service_data['scope'],
-                LtiServiceConnector::METHOD_GET,
-                $next_page,
-                null,
-                null,
-                'application/vnd.ims.lti-gs.v1.contextgroupcontainer+json'
-            );
-
-            $line_items = array_merge($line_items, $page['body']);
-            $next_page = false;
-            $link = $page['headers']['Link'];
-            if (preg_match(LtiServiceConnector::NEXT_PAGE_REGEX, $link, $matches)) {
-                $next_page = $matches[1];
-            }
-        }
+        $line_items = $this->getLineItems();
 
         // If there is only one item, then wrap it in an array so the foreach works
         if (isset($line_items['body']['id'])) {
@@ -151,7 +128,6 @@ class LtiAssignmentsGradesService
         if (isset($line_items['body']['id'])) {
             $line_items['body'] = [$line_items['body']];
         }
-
         return $line_items;
     }
 }

--- a/src/LtiAssignmentsGradesService.php
+++ b/src/LtiAssignmentsGradesService.php
@@ -68,7 +68,6 @@ class LtiAssignmentsGradesService
             $line_items = array_merge($line_items, $page['body']);
             $next_page = false;
             $link = $page['headers']['Link'];
-
             if (preg_match(LtiServiceConnector::NEXT_PAGE_REGEX, $link, $matches)) {
                 $next_page = $matches[1];
                 dump($next_page);
@@ -153,6 +152,7 @@ class LtiAssignmentsGradesService
         if (isset($line_items['body']['id'])) {
             $line_items['body'] = [$line_items['body']];
         }
+
         return $line_items;
     }
 }

--- a/src/LtiServiceConnector.php
+++ b/src/LtiServiceConnector.php
@@ -10,7 +10,7 @@ use Packback\Lti1p3\Interfaces\ILtiServiceConnector;
 
 class LtiServiceConnector implements ILtiServiceConnector
 {
-    const NEXT_PAGE_REGEX = '/^Link:.*<([^>]*)>; ?rel="next"/i';
+    const NEXT_PAGE_REGEX = '/<([^>]*)>; ?rel="next"/i';
 
     const METHOD_GET = 'GET';
     const METHOD_POST = 'POST';
@@ -31,7 +31,7 @@ class LtiServiceConnector implements ILtiServiceConnector
     {
         // Get a unique cache key for the access token
         $accessTokenKey = $this->getAccessTokenCacheKey($scopes);
-        // Get access token from cache if it exists
+        // // Get access token from cache if it exists
         $accessToken = $this->cache->getAccessToken($accessTokenKey);
         if ($accessToken) {
             return $accessToken;

--- a/src/LtiServiceConnector.php
+++ b/src/LtiServiceConnector.php
@@ -31,7 +31,7 @@ class LtiServiceConnector implements ILtiServiceConnector
     {
         // Get a unique cache key for the access token
         $accessTokenKey = $this->getAccessTokenCacheKey($scopes);
-        // // Get access token from cache if it exists
+        // Get access token from cache if it exists
         $accessToken = $this->cache->getAccessToken($accessTokenKey);
         if ($accessToken) {
             return $accessToken;


### PR DESCRIPTION
## Summary of Changes

AGS wasn't making use of the "next page" functionality, so I added that in. I also fixed the regex since when looking through the headers, the `Link` is actually the key and will never be found in the regex being checked against the value.

## Testing

Lots of manual testing. Confirmed I could get all 42 assignments in a context. I also tested 0 and 1.

- [x ] I have run `composer test`
- [x ] I have run `composer lint-fix`
