### PR TITLE
DEV-11392: check to see if headers Link is set

### DIFF
--- a/src/LtiAssignmentsGradesService.php
+++ b/src/LtiAssignmentsGradesService.php
@@ -112,6 +112,12 @@ class LtiAssignmentsGradesService
 
             $line_items = array_merge($line_items, $page['body']);
             $next_page = false;
+
+            // If the "Next" Link is not in the request headers, we can break the loop here.
+            if (!isset($page['headers']['Link'])) {
+                break;
+            }
+
             $link = $page['headers']['Link'];
 
             if (preg_match(LtiServiceConnector::NEXT_PAGE_REGEX, $link, $matches)) {


### PR DESCRIPTION
## Summary of Changes

I was only able to test this locally on Canvas. In dev testing, I found that many requests do NOT include this in the headers. If we don't have it, we can just break the loop since we don't need to make any more paginated requests.

## Testing

<!-- Describe how this PR has been tested, manually and automatically. -->

- [ ] I have run `composer test`
- [ ] I have run `composer lint-fix`
