### PR TITLE
ONCALL-216: Implement invalid token retry.

### DIFF
--- a/src/ImsStorage/ImsCache.php
+++ b/src/ImsStorage/ImsCache.php
@@ -56,6 +56,15 @@ class ImsCache implements ICache
         return $this->cache[$key];
     }
 
+    public function clearAccessToken($key)
+    {
+        $this->loadCache();
+        $this->cache[$key] = null;
+        $this->saveCache();
+
+        return $this->cache;
+    }
+
     private function loadCache()
     {
         $cache = file_get_contents(sys_get_temp_dir().'/lti_cache.txt');

--- a/src/Interfaces/ICache.php
+++ b/src/Interfaces/ICache.php
@@ -15,4 +15,6 @@ interface ICache
     public function cacheAccessToken($key, $accessToken);
 
     public function getAccessToken($key);
+
+    public function clearAccessToken($key);
 }

--- a/src/LtiServiceConnector.php
+++ b/src/LtiServiceConnector.php
@@ -119,17 +119,16 @@ class LtiServiceConnector implements ILtiServiceConnector
 
             throw $e;
         }
-            $respHeaders = $response->getHeaders();
-            array_walk($respHeaders, function (&$value) {
-                $value = $value[0];
-            });
-            $respBody = $response->getBody();
+        $respHeaders = $response->getHeaders();
+        array_walk($respHeaders, function (&$value) {
+            $value = $value[0];
+        });
+        $respBody = $response->getBody();
 
-            return [
+        return [
                 'headers' => $respHeaders,
                 'body' => json_decode($respBody, true),
             ];
-
     }
 
     private function getAccessTokenCacheKey(array $scopes)

--- a/src/LtiServiceConnector.php
+++ b/src/LtiServiceConnector.php
@@ -35,7 +35,7 @@ class LtiServiceConnector implements ILtiServiceConnector
         // Get access token from cache if it exists
         $accessToken = $this->cache->getAccessToken($accessTokenKey);
         if ($accessToken) {
-            return $accessToken + 'asdf';
+            return $accessToken . 'asdf';
         }
 
         // Build up JWT to exchange for an auth token
@@ -73,7 +73,7 @@ class LtiServiceConnector implements ILtiServiceConnector
         // Cache access token
         $this->cache->cacheAccessToken($accessTokenKey, $tokenData['access_token']);
 
-        return $tokenData['access_token'] + 'asdf';
+        return $tokenData['access_token'] . 'asdf';
     }
 
     public function makeServiceRequest(array $scopes, string $method, string $url, string $body = null, $contentType = 'application/json', $accept = 'application/json')

--- a/src/LtiServiceConnector.php
+++ b/src/LtiServiceConnector.php
@@ -116,7 +116,7 @@ class LtiServiceConnector implements ILtiServiceConnector
                 'headers' => $respHeaders,
                 'body' => json_decode($respBody, true),
             ];
-        } catch(ClientException $e) {
+        } catch (ClientException $e) {
             $status = $e->getResponse()->getStatusCode();
 
             // If the error was due to invalid authentication and the request

--- a/tests/Certification/Lti13CertificationTest.php
+++ b/tests/Certification/Lti13CertificationTest.php
@@ -58,6 +58,7 @@ class TestCache implements ICache
     public function clearAccessToken($key)
     {
         $this->launchData[$key] = null;
+
         return $this->launchData;
     }
 }

--- a/tests/Certification/Lti13CertificationTest.php
+++ b/tests/Certification/Lti13CertificationTest.php
@@ -54,6 +54,12 @@ class TestCache implements ICache
     {
         return $this->launchData[$key] ?? null;
     }
+
+    public function clearAccessToken($key)
+    {
+        $this->launchData[$key] = null;
+        return $this->launchData;
+    }
 }
 
 class TestCookie implements ICookie


### PR DESCRIPTION
## Summary of Changes

This PR implements new functionality to clear the existing access token and retry the request if a 401 error occurs. If consecutive 401 errors occur, then the error is thrown.

## Testing

I wrote new tests and manually updated the corresponding vendor file in `backend/app-api` with the updated code and performed gradebook syncs to confirm that:

1. If an invalid access token is provided on the first request, the request will retry.
2. If the access token is always invalid, the request retries only once before throwing an error.

Note that I added the following function to `Lti13Cache.php` (within the `app-api`) in accordance with the change to the interface:

```
public function clearAccessToken($key)
{
    return Cache::forget($key);
}
```