### PR TITLE
DEV-11396: add status code to service request response

### DIFF
--- a/src/LtiServiceConnector.php
+++ b/src/LtiServiceConnector.php
@@ -106,6 +106,7 @@ class LtiServiceConnector implements ILtiServiceConnector
         return [
             'headers' => $respHeaders,
             'body' => json_decode($respBody, true),
+            'status' => $response->getStatusCode(),
         ];
     }
 

--- a/tests/LtiServiceConnectorTest.php
+++ b/tests/LtiServiceConnectorTest.php
@@ -105,12 +105,14 @@ class LtiServiceConnectorTest extends TestCase
             'Server' => ['nginx'],
         ];
         $responseBody = ['some' => 'response'];
+        $responseStatus = 200;
         $expected = [
             'headers' => [
                 'Content-Type' => 'application/json',
                 'Server' => 'nginx',
             ],
             'body' => $responseBody,
+            'status' => $responseStatus,
         ];
 
         $this->mockCacheHasAccessToken();
@@ -123,6 +125,8 @@ class LtiServiceConnectorTest extends TestCase
             ->once()->andReturn($responseHeaders);
         $this->response->shouldReceive('getBody')
             ->once()->andReturn(json_encode($responseBody));
+        $this->response->shouldReceive('getStatusCode')
+            ->once()->andReturn(json_encode($responseStatus));
 
         $result = $this->connector->makeServiceRequest($scopes, $method, $url, $body);
 
@@ -143,12 +147,14 @@ class LtiServiceConnectorTest extends TestCase
             'Server' => ['nginx'],
         ];
         $responseBody = ['some' => 'response'];
+        $responseStatus = 200;
         $expected = [
             'headers' => [
                 'Content-Type' => 'application/json',
                 'Server' => 'nginx',
             ],
             'body' => $responseBody,
+            'status' => $responseStatus,
         ];
 
         $this->mockCacheHasAccessToken();
@@ -160,6 +166,8 @@ class LtiServiceConnectorTest extends TestCase
             ->once()->andReturn($responseHeaders);
         $this->response->shouldReceive('getBody')
             ->once()->andReturn(json_encode($responseBody));
+        $this->response->shouldReceive('getStatusCode')
+            ->once()->andReturn(json_encode($responseStatus));
 
         $result = $this->connector->makeServiceRequest($scopes, $method, $url);
 


### PR DESCRIPTION
## Summary of Changes

Adding the status code to the body of the response payload because many LMSes do not include a status in the request headers. This is causing us to think many syncs failed, even if they were successful.

## Testing

<!-- Describe how this PR has been tested, manually and automatically. -->

- [ x] I have run `composer test`
- [ x] I have run `composer lint-fix`
