### PR TITLE
MGMT-29 Make the LTI Service Connector into a generic API client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,7 @@
     ],
     "require": {
         "firebase/php-jwt": "^5.2",
-<<<<<<< HEAD
-        "guzzlehttp/oauth-subscriber": "^0.6.0",
-=======
         "guzzlehttp/oauth-subscriber": "^0.5.0 || ^0.6.0",
->>>>>>> master
         "phpseclib/phpseclib": "^2.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "firebase/php-jwt": "^5.2",
-        "guzzlehttp/oauth-subscriber": "^0.5.0",
+        "guzzlehttp/oauth-subscriber": "^0.6.0",
         "phpseclib/phpseclib": "^2.0"
     },
     "require-dev": {

--- a/src/Interfaces/ILtiServiceConnector.php
+++ b/src/Interfaces/ILtiServiceConnector.php
@@ -4,7 +4,7 @@ namespace Packback\Lti1p3\Interfaces;
 
 interface ILtiServiceConnector
 {
-    public function getAccessToken(array $scopes);
+    public function getAccessToken(ILtiRegistration $registration, array $scopes);
 
-    public function makeServiceRequest(array $scopes, string $method, string $url, string $body = null, $contentType = 'application/json', $accept = 'application/json');
+    public function makeServiceRequest(ILtiRegistration $registration, array $scopes, IServiceRequest $request, bool $shouldRetry = true);
 }

--- a/src/Interfaces/IServiceRequest.php
+++ b/src/Interfaces/IServiceRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Packback\Lti1p3\Interfaces;
+
+interface IServiceRequest
+{
+    public function getMethod(): string;
+
+    public function getUrl(): string;
+
+    public function getPayload(): array;
+
+    public function setAccessToken(string $accessToken): self;
+
+    public function setAccept(string $accept): self;
+
+    public function setContentType(string $contentType): self;
+}

--- a/src/Interfaces/IServiceRequest.php
+++ b/src/Interfaces/IServiceRequest.php
@@ -12,6 +12,8 @@ interface IServiceRequest
 
     public function setAccessToken(string $accessToken): self;
 
+    public function setBody(string $body): self;
+
     public function setAccept(string $accept): self;
 
     public function setContentType(string $contentType): self;

--- a/src/LtiAbstractService.php
+++ b/src/LtiAbstractService.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Packback\Lti1p3;
+
+use Packback\Lti1p3\Interfaces\ILtiRegistration;
+use Packback\Lti1p3\Interfaces\ILtiServiceConnector;
+use Packback\Lti1p3\Interfaces\IServiceRequest;
+
+abstract class LtiAbstractService
+{
+    private $serviceConnector;
+    private $registration;
+    private $serviceData;
+
+    public function __construct(
+        ILtiServiceConnector $serviceConnector,
+        ILtiRegistration $registration,
+        array $serviceData)
+    {
+        $this->serviceConnector = $serviceConnector;
+        $this->registration = $registration;
+        $this->serviceData = $serviceData;
+    }
+
+    public function makeServiceRequest(IServiceRequest $request)
+    {
+        return $this->serviceConnector->makeServiceRequest(
+            $this->registration,
+            $this->getScope(),
+            $request
+        );
+    }
+
+    public function getServiceData()
+    {
+        return $this->serviceData;
+    }
+
+    public function setServiceData(array $serviceData)
+    {
+        $this->serviceData = $serviceData;
+
+        return $this;
+    }
+
+    abstract public function getScope();
+}

--- a/src/LtiAssignmentsGradesService.php
+++ b/src/LtiAssignmentsGradesService.php
@@ -57,7 +57,7 @@ class LtiAssignmentsGradesService extends LtiAbstractService
         $request->setBody($newLineItem)
             ->setContentType('application/vnd.ims.lis.v2.lineitem+json')
             ->setAccept('application/vnd.ims.lis.v2.lineitem+json');
-        $created_lineitem = $this->makeServiceRequest($request);
+        $createdLineItems = $this->makeServiceRequest($request);
 
         return new LtiLineitem($created_lineitem['body']);
     }

--- a/src/LtiAssignmentsGradesService.php
+++ b/src/LtiAssignmentsGradesService.php
@@ -59,7 +59,7 @@ class LtiAssignmentsGradesService extends LtiAbstractService
             ->setAccept('application/vnd.ims.lis.v2.lineitem+json');
         $createdLineItems = $this->makeServiceRequest($request);
 
-        return new LtiLineitem($created_lineitem['body']);
+        return new LtiLineitem($createdLineItems['body']);
     }
 
     public function getGrades(LtiLineitem $lineitem)
@@ -67,9 +67,9 @@ class LtiAssignmentsGradesService extends LtiAbstractService
         $lineitem = $this->findOrCreateLineitem($lineitem);
         // Place '/results' before url params
         $pos = strpos($lineitem->getId(), '?');
-        $results_url = $pos === false ? $lineitem->getId().'/results' : substr_replace($lineitem->getId(), '/results', $pos, 0);
-        $request = new ServiceRequest(LtiServiceConnector::METHOD_GET, $results_url);
-        $reques->setAccept('application/vnd.ims.lis.v2.resultcontainer+json');
+        $resultsUrl = $pos === false ? $lineitem->getId().'/results' : substr_replace($lineitem->getId(), '/results', $pos, 0);
+        $request = new ServiceRequest(LtiServiceConnector::METHOD_GET, $resultsUrl);
+        $request->setAccept('application/vnd.ims.lis.v2.resultcontainer+json');
         $scores = $this->makeServiceRequest($request);
 
         return $scores['body'];

--- a/src/LtiCourseGroupsService.php
+++ b/src/LtiCourseGroupsService.php
@@ -18,7 +18,7 @@ class LtiCourseGroupsService extends LtiAbstractService
         while ($nextPage) {
             $request = new ServiceRequest(LtiServiceConnector::METHOD_GET, $nextPage);
             $request->setAccept('application/vnd.ims.lti-gs.v1.contextgroupcontainer+json');
-            $this->makeServiceRequest($request);
+            $page = $this->makeServiceRequest($request);
 
             $groups = array_merge($groups, $page['body']['groups']);
 
@@ -48,7 +48,7 @@ class LtiCourseGroupsService extends LtiAbstractService
         while ($nextPage) {
             $request = new ServiceRequest(LtiServiceConnector::METHOD_GET, $nextPage);
             $request->setAccept('application/vnd.ims.lti-gs.v1.contextgroupcontainer+json');
-            $this->makeServiceRequest($request);
+            $page = $this->makeServiceRequest($request);
 
             $sets = array_merge($sets, $page['body']['sets']);
 

--- a/src/ServiceRequest.php
+++ b/src/ServiceRequest.php
@@ -34,7 +34,7 @@ class ServiceRequest implements IServiceRequest
             'headers' => $this->getHeaders(),
         ];
 
-        $body = $this->body();
+        $body = $this->getBody();
         if ($body) {
             $payload['body'] = $body;
         }

--- a/src/ServiceRequest.php
+++ b/src/ServiceRequest.php
@@ -49,6 +49,13 @@ class ServiceRequest implements IServiceRequest
         return $this;
     }
 
+    public function setBody(string $body): IServiceRequest
+    {
+        $this->body = $body;
+
+        return $this;
+    }
+
     public function setAccept(string $accept): IServiceRequest
     {
         $this->accept = $accept;

--- a/src/ServiceRequest.php
+++ b/src/ServiceRequest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Packback\Lti1p3;
+
+use Packback\Lti1p3\Interfaces\IServiceRequest;
+
+class ServiceRequest implements IServiceRequest
+{
+    public $method;
+    public $url;
+    public $body;
+    public $contentType = 'application/json';
+    public $accept = 'application/json';
+
+    public function __construct(string $method, string $url)
+    {
+        $this->method = $method;
+        $this->url = $url;
+    }
+
+    public function getMethod(): string
+    {
+        return strtoupper($this->method);
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    public function getPayload(): array
+    {
+        $payload = [
+            'headers' => $this->getHeaders(),
+        ];
+
+        $body = $this->body();
+        if ($body) {
+            $payload['body'] = $body;
+        }
+
+        return $payload;
+    }
+
+    public function setAccessToken(string $accessToken): IServiceRequest
+    {
+        $this->accessToken = 'Bearer '.$accessToken;
+
+        return $this;
+    }
+
+    public function setAccept(string $accept): IServiceRequest
+    {
+        $this->accept = $accept;
+
+        return $this;
+    }
+
+    public function setContentType(string $contentType): IServiceRequest
+    {
+        $this->contentType = $contentType;
+
+        return $this;
+    }
+
+    private function getHeaders(): array
+    {
+        $headers = [
+            'Authorization' => $this->accessToken,
+            'Accept' => $this->accept,
+        ];
+
+        if (${$this}->getMethod() === LtiServiceConnector::METHOD_POST) {
+            $headers['Content-Type'] = $this->contentType;
+        }
+
+        return $headers;
+    }
+
+    private function getBody(): ?string
+    {
+        return $this->body;
+    }
+}

--- a/src/ServiceRequest.php
+++ b/src/ServiceRequest.php
@@ -77,7 +77,7 @@ class ServiceRequest implements IServiceRequest
             'Accept' => $this->accept,
         ];
 
-        if (${$this}->getMethod() === LtiServiceConnector::METHOD_POST) {
+        if ($this->getMethod() === LtiServiceConnector::METHOD_POST) {
             $headers['Content-Type'] = $this->contentType;
         }
 

--- a/tests/LtiAssignmentsGradesServiceTest.php
+++ b/tests/LtiAssignmentsGradesServiceTest.php
@@ -3,17 +3,22 @@
 namespace Tests;
 
 use Mockery;
+use Packback\Lti1p3\Interfaces\ILtiRegistration;
 use Packback\Lti1p3\Interfaces\ILtiServiceConnector;
 use Packback\Lti1p3\LtiAssignmentsGradesService;
 use PHPUnit\Framework\TestCase;
 
 class LtiAssignmentsGradesServiceTest extends TestCase
 {
+    public function setUp(): void
+    {
+        $this->connector = Mockery::mock(ILtiServiceConnector::class);
+        $this->registration = Mockery::mock(ILtiRegistration::class);
+    }
+
     public function testItInstantiates()
     {
-        $connector = Mockery::mock(ILtiServiceConnector::class);
-
-        $service = new LtiAssignmentsGradesService($connector, []);
+        $service = new LtiAssignmentsGradesService($this->connector, $this->registration, []);
 
         $this->assertInstanceOf(LtiAssignmentsGradesService::class, $service);
     }

--- a/tests/LtiCourseGroupsServiceTest.php
+++ b/tests/LtiCourseGroupsServiceTest.php
@@ -3,17 +3,22 @@
 namespace Tests;
 
 use Mockery;
+use Packback\Lti1p3\Interfaces\ILtiRegistration;
 use Packback\Lti1p3\Interfaces\ILtiServiceConnector;
 use Packback\Lti1p3\LtiCourseGroupsService;
 use PHPUnit\Framework\TestCase;
 
 class LtiCourseGroupsServiceTest extends TestCase
 {
+    public function setUp(): void
+    {
+        $this->connector = Mockery::mock(ILtiServiceConnector::class);
+        $this->registration = Mockery::mock(ILtiRegistration::class);
+    }
+
     public function testItInstantiates()
     {
-        $connector = Mockery::mock(ILtiServiceConnector::class);
-
-        $service = new LtiCourseGroupsService($connector, []);
+        $service = new LtiCourseGroupsService($this->connector, $this->registration, []);
 
         $this->assertInstanceOf(LtiCourseGroupsService::class, $service);
     }

--- a/tests/LtiNamesRolesProvisioningServiceTest.php
+++ b/tests/LtiNamesRolesProvisioningServiceTest.php
@@ -3,6 +3,7 @@
 namespace Tests;
 
 use Mockery;
+use Packback\Lti1p3\Interfaces\ILtiRegistration;
 use Packback\Lti1p3\Interfaces\ILtiServiceConnector;
 use Packback\Lti1p3\LtiNamesRolesProvisioningService;
 use PHPUnit\Framework\TestCase;
@@ -12,11 +13,12 @@ class LtiNamesRolesProvisioningServiceTest extends TestCase
     public function setUp(): void
     {
         $this->connector = Mockery::mock(ILtiServiceConnector::class);
+        $this->registration = Mockery::mock(ILtiRegistration::class);
     }
 
     public function testItInstantiates()
     {
-        $nrps = new LtiNamesRolesProvisioningService($this->connector, []);
+        $nrps = new LtiNamesRolesProvisioningService($this->connector, $this->registration, []);
 
         $this->assertInstanceOf(LtiNamesRolesProvisioningService::class, $nrps);
     }
@@ -25,7 +27,7 @@ class LtiNamesRolesProvisioningServiceTest extends TestCase
     {
         $expected = ['members'];
 
-        $nrps = new LtiNamesRolesProvisioningService($this->connector, [
+        $nrps = new LtiNamesRolesProvisioningService($this->connector, $this->registration, [
             'context_memberships_url' => 'url',
         ]);
         $this->connector->shouldReceive('makeServiceRequest')
@@ -44,7 +46,7 @@ class LtiNamesRolesProvisioningServiceTest extends TestCase
         $response = ['members'];
         $expected = array_merge($response, $response);
 
-        $nrps = new LtiNamesRolesProvisioningService($this->connector, [
+        $nrps = new LtiNamesRolesProvisioningService($this->connector, $this->registration, [
             'context_memberships_url' => 'url',
         ]);
         // First response


### PR DESCRIPTION
## Summary of Changes

<!-- A few sentences describing the big picture of your changes. -->

Converts the LtiServiceConnector into a generic API client. Previously, each instance of the service connector was directly tied to a specific LtiRegistration, so it could only send grades to one LMS. This PR shifts the coupling of the LtiRegistration to the instance of the specific service (AssignmentGradesService, NamesRolesProvisioningService). So rather than having an API client that is tied directly to a single LMS that then is used by the GradesService, we now have a generic API client that various services tied to specific LMSes can all use.

Here's how we used to do things when syncing grades for two different LMSes:
```php
$registrationForLms1 = $this->ltiRepository->findRegistrationByIssuer($issuer->issuer, $issuer->client_id);
$registrationForLms2 = $this->ltiRepository->findRegistrationByIssuer($issuer->issuer, $issuer->client_id);

$serviceConnector1 = new LtiServiceConnector($registrationForLms1, app(ICache::class), app(IClient::class));
$serviceConnector2 = new LtiServiceConnector($registrationForLms2, app(ICache::class), app(IClient::class));

$gradesService1 = new LtiAGS($serviceConnector1, $serviceData1);
$gradesService2 = new LtiAGS($serviceConnector2, $serviceData2);

$gradesService1->putGrade($gradeForLms1);
$gradesService2->putGrade($gradeForLms2);
```

Here's how it works now:
```php
$registrationForLms1 = $this->ltiRepository->findRegistrationByIssuer($issuer->issuer, $issuer->client_id);
$registrationForLms2 = $this->ltiRepository->findRegistrationByIssuer($issuer->issuer, $issuer->client_id);

$gradesService1 = new LtiAGS(app(ILtiServiceConnector::class), $registrationForLms1, $serviceData1);
$gradesService2 = new LtiAGS(app(ILtiServiceConnector::class), $registrationForLms2, $serviceData2);

$gradesService1->putGrade($gradeForLms1);
$gradesService2->putGrade($gradeForLms2);
```

## Testing

<!-- Describe how this PR has been tested, manually and automatically. -->

- [x] I have run `composer test`
- [x] I have run `composer lint-fix`

I manually tested the implementation here, and was able to successfully sync grades: https://github.com/packbackbooks/questions/compare/stateless-service-connector
