### PR TITLE
MGMT-31 Implement a `getAll` method on the Service Connector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .idea
 .phpunit.result.cache
 .php_cs.cache
+.php-cs-fixer.cache
 
 build
 composer.lock

--- a/UPGRADES.md
+++ b/UPGRADES.md
@@ -1,3 +1,26 @@
+## 2.0 to 3.0
+
+### New method implemented on the `ICache`
+
+Version 3.0 introduced changes to the `Packback\Lti1p3\Interfaces\ICache` interface, adding one methods: `clearAccessToken()`. This methods must be implemented to any custom implementations of the interface. The [Laravel Implementation Guide](https://github.com/packbackbooks/lti-1-3-php-library/wiki/Laravel-Implementation-Guide#cache) contains an example.
+
+### Using GuzzleHttp\Client instead of curl
+
+The `Packback\Lti1p3\LtiServiceConnector` now uses Guzzle instead of curl to make requests. This puts control of this client and it's configuration in the hands of the developer. The section below contains information on implementing this change.
+
+### Changes to the LtiServiceConnector and LTI services
+
+The implementation of the `Packback\Lti1p3\LtiServiceConnector` changed to act as a general API Client for the various LTI service (Assignment Grades, Names Roles Provisioning, etc.) Specifically, the constructor for the following classes now accept different arguments:
+
+- `LtiAssignmentGradesService`
+- `LtiCourseGroupsService`
+- `LtiNamesRolesProvisioningService`
+- `LtiServiceConnector`
+
+The `LtiServiceConnector` now only accepts an `ICache` and `GuzzleHttp\Client`, and does not need an `ILtiRegistration`. The [Laravel Implementation Guide](https://github.com/packbackbooks/lti-1-3-php-library/wiki/Laravel-Implementation-Guide#installation) contains an example of how to implement the service connector and configure the client.
+
+The other LTI services now accept an `ILtiServiceConnector`, `ILtiRegistration`, and `$serviceData` (the registration was added as a new argument since it is no longer required for the `LtiServiceConnector`).
+
 ## 1.0 to 2.0
 
 ### Renamed Interfaces

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "phpseclib/phpseclib": "^2.0"
     },
     "require-dev": {
-        "matt-allan/laravel-code-style": "^0.6.0",
+        "matt-allan/laravel-code-style": "dev-main",
         "mockery/mockery": "^1.4",
         "nesbot/carbon": "^2.43",
         "phpunit/phpunit": "^9.5"

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "firebase/php-jwt": "^5.2",
-        "guzzlehttp/oauth-subscriber": "^0.5.0 || ^0.6.0",
+        "guzzlehttp/guzzle": "^7.0",
         "phpseclib/phpseclib": "^2.0"
     },
     "require-dev": {

--- a/src/Interfaces/ILtiServiceConnector.php
+++ b/src/Interfaces/ILtiServiceConnector.php
@@ -6,5 +6,12 @@ interface ILtiServiceConnector
 {
     public function getAccessToken(ILtiRegistration $registration, array $scopes);
 
-    public function makeServiceRequest(ILtiRegistration $registration, array $scopes, IServiceRequest $request, bool $shouldRetry = true);
+    public function makeServiceRequest(
+        ILtiRegistration $registration,
+        array $scopes,
+        IServiceRequest $request,
+        bool $shouldRetry = true
+    ): array;
+
+    public function getAll(ILtiRegistration $registration, array $scopes, IServiceRequest $request): array;
 }

--- a/src/Interfaces/ILtiServiceConnector.php
+++ b/src/Interfaces/ILtiServiceConnector.php
@@ -13,5 +13,10 @@ interface ILtiServiceConnector
         bool $shouldRetry = true
     ): array;
 
-    public function getAll(ILtiRegistration $registration, array $scopes, IServiceRequest $request): array;
+    public function getAll(
+        ILtiRegistration $registration,
+        array $scopes,
+        IServiceRequest $request,
+        string $key
+    ): array;
 }

--- a/src/Interfaces/IServiceRequest.php
+++ b/src/Interfaces/IServiceRequest.php
@@ -10,6 +10,8 @@ interface IServiceRequest
 
     public function getPayload(): array;
 
+    public function setUrl(string $url): self;
+
     public function setAccessToken(string $accessToken): self;
 
     public function setBody(string $body): self;

--- a/src/LtiAbstractService.php
+++ b/src/LtiAbstractService.php
@@ -22,15 +22,6 @@ abstract class LtiAbstractService
         $this->serviceData = $serviceData;
     }
 
-    public function makeServiceRequest(IServiceRequest $request): array
-    {
-        return $this->serviceConnector->makeServiceRequest(
-            $this->registration,
-            $this->getScope(),
-            $request
-        );
-    }
-
     public function getServiceData(): array
     {
         return $this->serviceData;
@@ -44,4 +35,23 @@ abstract class LtiAbstractService
     }
 
     abstract public function getScope(): array;
+
+    protected function makeServiceRequest(IServiceRequest $request): array
+    {
+        return $this->serviceConnector->makeServiceRequest(
+            $this->registration,
+            $this->getScope(),
+            $request
+        );
+    }
+
+    protected function getAll(IServiceRequest $request, string $key): array
+    {
+        return $this->serviceConnector->getAll(
+            $this->registration,
+            $this->getScope(),
+            $request,
+            $key
+        );
+    }
 }

--- a/src/LtiAbstractService.php
+++ b/src/LtiAbstractService.php
@@ -22,7 +22,7 @@ abstract class LtiAbstractService
         $this->serviceData = $serviceData;
     }
 
-    public function makeServiceRequest(IServiceRequest $request)
+    public function makeServiceRequest(IServiceRequest $request): array
     {
         return $this->serviceConnector->makeServiceRequest(
             $this->registration,
@@ -31,17 +31,17 @@ abstract class LtiAbstractService
         );
     }
 
-    public function getServiceData()
+    public function getServiceData(): array
     {
         return $this->serviceData;
     }
 
-    public function setServiceData(array $serviceData)
+    public function setServiceData(array $serviceData): self
     {
         $this->serviceData = $serviceData;
 
         return $this;
     }
 
-    abstract public function getScope();
+    abstract public function getScope(): array;
 }

--- a/src/LtiAssignmentsGradesService.php
+++ b/src/LtiAssignmentsGradesService.php
@@ -4,6 +4,10 @@ namespace Packback\Lti1p3;
 
 class LtiAssignmentsGradesService extends LtiAbstractService
 {
+    public const CONTENTTYPE_SCORE = 'application/vnd.ims.lis.v1.score+json';
+    public const CONTENTTYPE_LINEITEM = 'application/vnd.ims.lis.v2.lineitem+json';
+    public const CONTENTTYPE_RESULTCONTAINER = 'application/vnd.ims.lis.v2.resultcontainer+json';
+
     public function getScope(): array
     {
         return $this->getServiceData()['scope'];
@@ -33,7 +37,7 @@ class LtiAssignmentsGradesService extends LtiAbstractService
 
         $request = new ServiceRequest(LtiServiceConnector::METHOD_POST, $scoreUrl);
         $request->setBody($grade);
-        $request->setContentType('application/vnd.ims.lis.v1.score+json');
+        $request->setContentType(static::CONTENTTYPE_SCORE);
 
         return $this->makeServiceRequest($request);
     }
@@ -55,8 +59,8 @@ class LtiAssignmentsGradesService extends LtiAbstractService
         }
         $request = new ServiceRequest(LtiServiceConnector::METHOD_POST, $this->getServiceData()['lineitems']);
         $request->setBody($newLineItem)
-            ->setContentType('application/vnd.ims.lis.v2.lineitem+json')
-            ->setAccept('application/vnd.ims.lis.v2.lineitem+json');
+            ->setContentType(static::CONTENTTYPE_LINEITEM)
+            ->setAccept(static::CONTENTTYPE_LINEITEM);
         $createdLineItems = $this->makeServiceRequest($request);
 
         return new LtiLineitem($createdLineItems['body']);
@@ -69,7 +73,7 @@ class LtiAssignmentsGradesService extends LtiAbstractService
         $pos = strpos($lineitem->getId(), '?');
         $resultsUrl = $pos === false ? $lineitem->getId().'/results' : substr_replace($lineitem->getId(), '/results', $pos, 0);
         $request = new ServiceRequest(LtiServiceConnector::METHOD_GET, $resultsUrl);
-        $request->setAccept('application/vnd.ims.lis.v2.resultcontainer+json');
+        $request->setAccept();
         $scores = $this->makeServiceRequest($request);
 
         return $scores['body'];
@@ -85,7 +89,7 @@ class LtiAssignmentsGradesService extends LtiAbstractService
             LtiServiceConnector::METHOD_GET,
             $this->getServiceData()['lineitems']
         );
-        $request->setAccept('application/vnd.ims.lti-gs.v1.contextgroupcontainer+json');
+        $request->setAccept(static::CONTENTTYPE_RESULTCONTAINER);
 
         $lineitems = $this->getAll($request, 'lineitems');
 

--- a/src/LtiAssignmentsGradesService.php
+++ b/src/LtiAssignmentsGradesService.php
@@ -87,7 +87,7 @@ class LtiAssignmentsGradesService extends LtiAbstractService
         );
         $request->setAccept('application/vnd.ims.lti-gs.v1.contextgroupcontainer+json');
 
-        $lineitems = $this->getAll($request);
+        $lineitems = $this->getAll($request, 'lineitems');
 
         // If there is only one item, then wrap it in an array so the foreach works
         if (isset($lineitems['body']['id'])) {

--- a/src/LtiCourseGroupsService.php
+++ b/src/LtiCourseGroupsService.php
@@ -17,7 +17,7 @@ class LtiCourseGroupsService extends LtiAbstractService
         );
         $request->setAccept('application/vnd.ims.lti-gs.v1.contextgroupcontainer+json');
 
-        return $this->getAll($request);
+        return $this->getAll($request, 'groups');
     }
 
     public function getSets(): array
@@ -33,7 +33,7 @@ class LtiCourseGroupsService extends LtiAbstractService
         );
         $request->setAccept('application/vnd.ims.lti-gs.v1.contextgroupcontainer+json');
 
-        return $this->makeServiceRequest($request);
+        return $this->getAll($request, 'sets');
     }
 
     public function getGroupsBySet()

--- a/src/LtiCourseGroupsService.php
+++ b/src/LtiCourseGroupsService.php
@@ -26,7 +26,7 @@ class LtiCourseGroupsService extends LtiAbstractService
         if (!isset($this->getServiceData()['context_group_sets_url'])) {
             return [];
         }
-        
+
         $request = new ServiceRequest(
             LtiServiceConnector::METHOD_GET,
             $this->getServiceData()['context_group_sets_url']

--- a/src/LtiCourseGroupsService.php
+++ b/src/LtiCourseGroupsService.php
@@ -4,64 +4,36 @@ namespace Packback\Lti1p3;
 
 class LtiCourseGroupsService extends LtiAbstractService
 {
-    public function getScope()
+    public function getScope(): array
     {
         return $this->getServiceData()['scope'];
     }
 
-    public function getGroups()
+    public function getGroups(): array
     {
-        $groups = [];
+        $request = new ServiceRequest(
+            LtiServiceConnector::METHOD_GET,
+            $this->getServiceData()['context_groups_url']
+        );
+        $request->setAccept('application/vnd.ims.lti-gs.v1.contextgroupcontainer+json');
 
-        $nextPage = $this->getServiceData()['context_groups_url'];
-
-        while ($nextPage) {
-            $request = new ServiceRequest(LtiServiceConnector::METHOD_GET, $nextPage);
-            $request->setAccept('application/vnd.ims.lti-gs.v1.contextgroupcontainer+json');
-            $this->makeServiceRequest($request);
-
-            $groups = array_merge($groups, $page['body']['groups']);
-
-            $nextPage = false;
-            foreach ($page['headers'] as $header) {
-                if (preg_match(LtiServiceConnector::NEXT_PAGE_REGEX, $header, $matches)) {
-                    $nextPage = $matches[1];
-                    break;
-                }
-            }
-        }
-
-        return $groups;
+        return $this->getAll($request);
     }
 
-    public function getSets()
+    public function getSets(): array
     {
-        $sets = [];
-
         // Sets are optional.
         if (!isset($this->getServiceData()['context_group_sets_url'])) {
             return [];
         }
+        
+        $request = new ServiceRequest(
+            LtiServiceConnector::METHOD_GET,
+            $this->getServiceData()['context_group_sets_url']
+        );
+        $request->setAccept('application/vnd.ims.lti-gs.v1.contextgroupcontainer+json');
 
-        $nextPage = $this->getServiceData()['context_group_sets_url'];
-
-        while ($nextPage) {
-            $request = new ServiceRequest(LtiServiceConnector::METHOD_GET, $nextPage);
-            $request->setAccept('application/vnd.ims.lti-gs.v1.contextgroupcontainer+json');
-            $this->makeServiceRequest($request);
-
-            $sets = array_merge($sets, $page['body']['sets']);
-
-            $nextPage = false;
-            foreach ($page['headers'] as $header) {
-                if (preg_match(LtiServiceConnector::NEXT_PAGE_REGEX, $header, $matches)) {
-                    $nextPage = $matches[1];
-                    break;
-                }
-            }
-        }
-
-        return $sets;
+        return $this->makeServiceRequest($request);
     }
 
     public function getGroupsBySet()

--- a/src/LtiCourseGroupsService.php
+++ b/src/LtiCourseGroupsService.php
@@ -4,6 +4,8 @@ namespace Packback\Lti1p3;
 
 class LtiCourseGroupsService extends LtiAbstractService
 {
+    public const CONTENTTYPE_CONTEXTGROUPCONTAINER = 'application/vnd.ims.lti-gs.v1.contextgroupcontainer+json';
+
     public function getScope(): array
     {
         return $this->getServiceData()['scope'];
@@ -15,7 +17,7 @@ class LtiCourseGroupsService extends LtiAbstractService
             LtiServiceConnector::METHOD_GET,
             $this->getServiceData()['context_groups_url']
         );
-        $request->setAccept('application/vnd.ims.lti-gs.v1.contextgroupcontainer+json');
+        $request->setAccept(static::CONTENTTYPE_CONTEXTGROUPCONTAINER);
 
         return $this->getAll($request, 'groups');
     }
@@ -31,7 +33,7 @@ class LtiCourseGroupsService extends LtiAbstractService
             LtiServiceConnector::METHOD_GET,
             $this->getServiceData()['context_group_sets_url']
         );
-        $request->setAccept('application/vnd.ims.lti-gs.v1.contextgroupcontainer+json');
+        $request->setAccept(static::CONTENTTYPE_CONTEXTGROUPCONTAINER);
 
         return $this->getAll($request, 'sets');
     }

--- a/src/LtiMessageLaunch.php
+++ b/src/LtiMessageLaunch.php
@@ -55,7 +55,7 @@ class LtiMessageLaunch
         IDatabase $database,
         ICache $cache = null,
         ICookie $cookie = null,
-        ILtiServiceConnector $serviceConnector = nul
+        ILtiServiceConnector $serviceConnector = null
         ) {
         return new LtiMessageLaunch($database, $cache, $cookie, $serviceConnector);
     }

--- a/src/LtiMessageLaunch.php
+++ b/src/LtiMessageLaunch.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Client;
 use Packback\Lti1p3\Interfaces\ICache;
 use Packback\Lti1p3\Interfaces\ICookie;
 use Packback\Lti1p3\Interfaces\IDatabase;
+use Packback\Lti1p3\Interfaces\ILtiServiceConnector;
 use Packback\Lti1p3\MessageValidators\DeepLinkMessageValidator;
 use Packback\Lti1p3\MessageValidators\ResourceMessageValidator;
 use Packback\Lti1p3\MessageValidators\SubmissionReviewMessageValidator;

--- a/src/LtiNamesRolesProvisioningService.php
+++ b/src/LtiNamesRolesProvisioningService.php
@@ -16,7 +16,7 @@ class LtiNamesRolesProvisioningService extends LtiAbstractService
             $this->getServiceData()['context_memberships_url']
         );
         $request->setAccept('application/vnd.ims.lti-nrps.v2.membershipcontainer+json');
-        
+
         return $this->getAll($request);
     }
 }

--- a/src/LtiNamesRolesProvisioningService.php
+++ b/src/LtiNamesRolesProvisioningService.php
@@ -4,33 +4,19 @@ namespace Packback\Lti1p3;
 
 class LtiNamesRolesProvisioningService extends LtiAbstractService
 {
-    public function getScope()
+    public function getScope(): array
     {
         return [LtiConstants::NRPS_SCOPE_MEMBERSHIP_READONLY];
     }
 
-    public function getMembers()
+    public function getMembers(): array
     {
-        $members = [];
-
-        $nextPage = $this->getServiceData()['context_memberships_url'];
-
-        while ($nextPage) {
-            $request = new ServiceRequest(LtiServiceConnector::METHOD_GET, $nextPage);
-            $request->setAccept('application/vnd.ims.lti-nrps.v2.membershipcontainer+json');
-            $page = $this->makeServiceRequest($request);
-
-            $members = array_merge($members, $page['body']['members']);
-
-            $nextPage = false;
-            foreach ($page['headers'] as $header) {
-                if (preg_match(LtiServiceConnector::NEXT_PAGE_REGEX, $header, $matches)) {
-                    $nextPage = $matches[1];
-                    break;
-                }
-            }
-        }
-
-        return $members;
+        $request = new ServiceRequest(
+            LtiServiceConnector::METHOD_GET,
+            $this->getServiceData()['context_memberships_url']
+        );
+        $request->setAccept('application/vnd.ims.lti-nrps.v2.membershipcontainer+json');
+        
+        return $this->getAll($request);
     }
 }

--- a/src/LtiNamesRolesProvisioningService.php
+++ b/src/LtiNamesRolesProvisioningService.php
@@ -4,6 +4,8 @@ namespace Packback\Lti1p3;
 
 class LtiNamesRolesProvisioningService extends LtiAbstractService
 {
+    public const CONTENTTYPE_MEMBERSHIPCONTAINER = 'application/vnd.ims.lti-nrps.v2.membershipcontainer+json';
+
     public function getScope(): array
     {
         return [LtiConstants::NRPS_SCOPE_MEMBERSHIP_READONLY];
@@ -15,7 +17,7 @@ class LtiNamesRolesProvisioningService extends LtiAbstractService
             LtiServiceConnector::METHOD_GET,
             $this->getServiceData()['context_memberships_url']
         );
-        $request->setAccept('application/vnd.ims.lti-nrps.v2.membershipcontainer+json');
+        $request->setAccept(static::CONTENTTYPE_MEMBERSHIPCONTAINER);
 
         return $this->getAll($request, 'members');
     }

--- a/src/LtiNamesRolesProvisioningService.php
+++ b/src/LtiNamesRolesProvisioningService.php
@@ -17,6 +17,6 @@ class LtiNamesRolesProvisioningService extends LtiAbstractService
         );
         $request->setAccept('application/vnd.ims.lti-nrps.v2.membershipcontainer+json');
 
-        return $this->getAll($request);
+        return $this->getAll($request, 'members');
     }
 }

--- a/src/LtiServiceConnector.php
+++ b/src/LtiServiceConnector.php
@@ -122,7 +122,7 @@ class LtiServiceConnector implements ILtiServiceConnector
         string $key
     ): array {
         if ($request->getMethod() !== static::METHOD_GET) {
-            throw new \Exception('An invalid method was specified for a request to get items.');
+            throw new \Exception('An invalid method was specified by an LTI service requesting all items.');
         }
 
         $results = [];

--- a/src/LtiServiceConnector.php
+++ b/src/LtiServiceConnector.php
@@ -12,10 +12,10 @@ use Packback\Lti1p3\Interfaces\IServiceRequest;
 
 class LtiServiceConnector implements ILtiServiceConnector
 {
-    const NEXT_PAGE_REGEX = '/<([^>]*)>; ?rel="next"/i';
+    public const NEXT_PAGE_REGEX = '/<([^>]*)>; ?rel="next"/i';
 
-    const METHOD_GET = 'GET';
-    const METHOD_POST = 'POST';
+    public const METHOD_GET = 'GET';
+    public const METHOD_POST = 'POST';
 
     private $cache;
     private $client;
@@ -39,12 +39,12 @@ class LtiServiceConnector implements ILtiServiceConnector
         // Build up JWT to exchange for an auth token
         $clientId = $registration->getClientId();
         $jwtClaim = [
-                'iss' => $clientId,
-                'sub' => $clientId,
-                'aud' => $registration->getAuthServer(),
-                'iat' => time() - 5,
-                'exp' => time() + 60,
-                'jti' => 'lti-service-token'.hash('sha256', random_bytes(64)),
+            'iss' => $clientId,
+            'sub' => $clientId,
+            'aud' => $registration->getAuthServer(),
+            'iat' => time() - 5,
+            'exp' => time() + 60,
+            'jti' => 'lti-service-token'.hash('sha256', random_bytes(64)),
         ];
 
         // Sign the JWT with our private key (given by the platform on registration)

--- a/src/ServiceRequest.php
+++ b/src/ServiceRequest.php
@@ -42,6 +42,13 @@ class ServiceRequest implements IServiceRequest
         return $payload;
     }
 
+    public function setUrl(string $url): IServiceRequest
+    {
+        $this->url = $url;
+
+        return $this;
+    }
+
     public function setAccessToken(string $accessToken): IServiceRequest
     {
         $this->accessToken = 'Bearer '.$accessToken;

--- a/tests/Certification/Lti13CertificationTest.php
+++ b/tests/Certification/Lti13CertificationTest.php
@@ -14,7 +14,7 @@ use Packback\Lti1p3\LtiException;
 use Packback\Lti1p3\LtiMessageLaunch;
 use Packback\Lti1p3\LtiOidcLogin;
 use Packback\Lti1p3\LtiRegistration;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 class TestCache implements ICache
 {

--- a/tests/Certification/Lti13CertificationTest.php
+++ b/tests/Certification/Lti13CertificationTest.php
@@ -104,12 +104,12 @@ class TestDb implements IDatabase
 
 class Lti13CertificationTest extends TestCase
 {
-    const ISSUER_URL = 'https://ltiadvantagevalidator.imsglobal.org';
-    const JWKS_FILE = '/tmp/jwks.json';
-    const CERT_DATA_DIR = __DIR__.'/../data/certification/';
-    const PRIVATE_KEY = __DIR__.'/../data/private.key';
+    public const ISSUER_URL = 'https://ltiadvantagevalidator.imsglobal.org';
+    public const JWKS_FILE = '/tmp/jwks.json';
+    public const CERT_DATA_DIR = __DIR__.'/../data/certification/';
+    public const PRIVATE_KEY = __DIR__.'/../data/private.key';
 
-    const STATE = 'state';
+    public const STATE = 'state';
 
     private $issuer;
     private $key;

--- a/tests/ImsStorage/ImsCacheTest.php
+++ b/tests/ImsStorage/ImsCacheTest.php
@@ -3,7 +3,7 @@
 namespace Tests\ImsStorage;
 
 use Packback\Lti1p3\ImsStorage\ImsCache;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 class ImsCacheTest extends TestCase
 {

--- a/tests/ImsStorage/ImsCookieTest.php
+++ b/tests/ImsStorage/ImsCookieTest.php
@@ -3,7 +3,7 @@
 namespace Tests\ImsStorage;
 
 use Packback\Lti1p3\ImsStorage\ImsCookie;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 class ImsCookieTest extends TestCase
 {

--- a/tests/JwksEndpointTest.php
+++ b/tests/JwksEndpointTest.php
@@ -6,7 +6,6 @@ use Mockery;
 use Packback\Lti1p3\Interfaces\IDatabase;
 use Packback\Lti1p3\Interfaces\ILtiRegistration;
 use Packback\Lti1p3\JwksEndpoint;
-use PHPUnit\Framework\TestCase;
 
 class JwksEndpointTest extends TestCase
 {

--- a/tests/LtiAssignmentsGradesServiceTest.php
+++ b/tests/LtiAssignmentsGradesServiceTest.php
@@ -6,7 +6,6 @@ use Mockery;
 use Packback\Lti1p3\Interfaces\ILtiRegistration;
 use Packback\Lti1p3\Interfaces\ILtiServiceConnector;
 use Packback\Lti1p3\LtiAssignmentsGradesService;
-use PHPUnit\Framework\TestCase;
 
 class LtiAssignmentsGradesServiceTest extends TestCase
 {

--- a/tests/LtiCourseGroupsServiceTest.php
+++ b/tests/LtiCourseGroupsServiceTest.php
@@ -6,7 +6,6 @@ use Mockery;
 use Packback\Lti1p3\Interfaces\ILtiRegistration;
 use Packback\Lti1p3\Interfaces\ILtiServiceConnector;
 use Packback\Lti1p3\LtiCourseGroupsService;
-use PHPUnit\Framework\TestCase;
 
 class LtiCourseGroupsServiceTest extends TestCase
 {

--- a/tests/LtiDeepLinkResourceTest.php
+++ b/tests/LtiDeepLinkResourceTest.php
@@ -5,7 +5,6 @@ namespace Tests;
 use Mockery;
 use Packback\Lti1p3\LtiDeepLinkResource;
 use Packback\Lti1p3\LtiLineitem;
-use PHPUnit\Framework\TestCase;
 
 class LtiDeepLinkResourceTest extends TestCase
 {

--- a/tests/LtiDeepLinkTest.php
+++ b/tests/LtiDeepLinkTest.php
@@ -5,7 +5,6 @@ namespace Tests;
 use Mockery;
 use Packback\Lti1p3\Interfaces\ILtiRegistration;
 use Packback\Lti1p3\LtiDeepLink;
-use PHPUnit\Framework\TestCase;
 
 class LtiDeepLinkTest extends TestCase
 {

--- a/tests/LtiDeploymentTest.php
+++ b/tests/LtiDeploymentTest.php
@@ -3,7 +3,6 @@
 namespace Tests;
 
 use Packback\Lti1p3\LtiDeployment;
-use PHPUnit\Framework\TestCase;
 
 class LtiDeploymentTest extends TestCase
 {

--- a/tests/LtiGradeSubmissionReviewTest.php
+++ b/tests/LtiGradeSubmissionReviewTest.php
@@ -3,7 +3,6 @@
 namespace Tests;
 
 use Packback\Lti1p3\LtiGradeSubmissionReview;
-use PHPUnit\Framework\TestCase;
 
 class LtiGradeSubmissionReviewTest extends TestCase
 {

--- a/tests/LtiGradeTest.php
+++ b/tests/LtiGradeTest.php
@@ -3,7 +3,6 @@
 namespace Tests;
 
 use Packback\Lti1p3\LtiGrade;
-use PHPUnit\Framework\TestCase;
 
 class LtiGradeTest extends TestCase
 {

--- a/tests/LtiLineitemTest.php
+++ b/tests/LtiLineitemTest.php
@@ -3,7 +3,6 @@
 namespace Tests;
 
 use Packback\Lti1p3\LtiLineitem;
-use PHPUnit\Framework\TestCase;
 
 class LtiLineitemTest extends TestCase
 {

--- a/tests/LtiMessageLaunchTest.php
+++ b/tests/LtiMessageLaunchTest.php
@@ -7,7 +7,6 @@ use Packback\Lti1p3\Interfaces\ICache;
 use Packback\Lti1p3\Interfaces\ICookie;
 use Packback\Lti1p3\Interfaces\IDatabase;
 use Packback\Lti1p3\LtiMessageLaunch;
-use PHPUnit\Framework\TestCase;
 
 class LtiMessageLaunchTest extends TestCase
 {

--- a/tests/LtiNamesRolesProvisioningServiceTest.php
+++ b/tests/LtiNamesRolesProvisioningServiceTest.php
@@ -30,37 +30,8 @@ class LtiNamesRolesProvisioningServiceTest extends TestCase
         $nrps = new LtiNamesRolesProvisioningService($this->connector, $this->registration, [
             'context_memberships_url' => 'url',
         ]);
-        $this->connector->shouldReceive('makeServiceRequest')
-            ->once()->andReturn([
-                'headers' => [],
-                'body' => ['members' => $expected],
-            ]);
-
-        $result = $nrps->getMembers();
-
-        $this->assertEquals($expected, $result);
-    }
-
-    public function testItGetsMembersIteratively()
-    {
-        $response = ['members'];
-        $expected = array_merge($response, $response);
-
-        $nrps = new LtiNamesRolesProvisioningService($this->connector, $this->registration, [
-            'context_memberships_url' => 'url',
-        ]);
-        // First response
-        $this->connector->shouldReceive('makeServiceRequest')
-            ->once()->andReturn([
-                'headers' => ['Link:Something<else>;rel="next"'],
-                'body' => ['members' => $response],
-            ]);
-        // Second response
-        $this->connector->shouldReceive('makeServiceRequest')
-            ->once()->andReturn([
-                'headers' => [],
-                'body' => ['members' => $response],
-            ]);
+        $this->connector->shouldReceive('getAll')
+            ->once()->andReturn($expected);
 
         $result = $nrps->getMembers();
 

--- a/tests/LtiNamesRolesProvisioningServiceTest.php
+++ b/tests/LtiNamesRolesProvisioningServiceTest.php
@@ -6,7 +6,6 @@ use Mockery;
 use Packback\Lti1p3\Interfaces\ILtiRegistration;
 use Packback\Lti1p3\Interfaces\ILtiServiceConnector;
 use Packback\Lti1p3\LtiNamesRolesProvisioningService;
-use PHPUnit\Framework\TestCase;
 
 class LtiNamesRolesProvisioningServiceTest extends TestCase
 {

--- a/tests/LtiOidcLoginTest.php
+++ b/tests/LtiOidcLoginTest.php
@@ -8,7 +8,6 @@ use Packback\Lti1p3\Interfaces\ICookie;
 use Packback\Lti1p3\Interfaces\IDatabase;
 use Packback\Lti1p3\LtiOidcLogin;
 use Packback\Lti1p3\OidcException;
-use PHPUnit\Framework\TestCase;
 
 class LtiOidcLoginTest extends TestCase
 {

--- a/tests/LtiRegistrationTest.php
+++ b/tests/LtiRegistrationTest.php
@@ -3,7 +3,6 @@
 namespace Tests;
 
 use Packback\Lti1p3\LtiRegistration;
-use PHPUnit\Framework\TestCase;
 
 class LtiRegistrationTest extends TestCase
 {

--- a/tests/LtiServiceConnectorTest.php
+++ b/tests/LtiServiceConnectorTest.php
@@ -10,7 +10,6 @@ use Packback\Lti1p3\Interfaces\ILtiRegistration;
 use Packback\Lti1p3\Interfaces\IServiceRequest;
 use Packback\Lti1p3\LtiRegistration;
 use Packback\Lti1p3\LtiServiceConnector;
-use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 
 class LtiServiceConnectorTest extends TestCase
@@ -120,12 +119,7 @@ class LtiServiceConnectorTest extends TestCase
 
         $this->request->shouldReceive('setAccessToken')
             ->once()->andReturn($this->request);
-        $this->request->shouldReceive('getMethod')
-            ->once()->andReturn($this->method);
-        $this->request->shouldReceive('getUrl')
-            ->once()->andReturn($this->url);
-        $this->request->shouldReceive('getPayload')
-            ->once()->andReturn($this->requestPayload);
+        $this->mockMakeRequest();
 
         $this->mockCacheHasAccessToken();
         $this->client->shouldReceive('request')
@@ -172,31 +166,27 @@ class LtiServiceConnectorTest extends TestCase
             'status' => $this->responseStatus,
         ];
 
+        // It gets an access token
+        $this->mockCacheHasAccessToken();
+        // It sets it on the request
         $this->request->shouldReceive('setAccessToken')
             ->once()->andReturn($this->request);
-        $this->request->shouldReceive('getMethod')
-            ->once()->andReturn($this->method);
-        $this->request->shouldReceive('getUrl')
-            ->once()->andReturn($this->url);
-        $this->request->shouldReceive('getPayload')
-            ->once()->andReturn($this->requestPayload);
+        // It makes the request
+        $this->mockMakeRequest();
 
+        // The request fails
+        $this->mockRequestReturnsA401();
+
+        // It clears the access token from the cache
         $this->mockCacheHasAccessToken();
-
-        // Mock the response failing on the first request
-        $mockError = Mockery::mock(ClientException::class);
-        $mockResponse = Mockery::mock(ResponseInterface::class);
-        $this->client->shouldReceive('request')
-            ->with($this->method, $this->url, [
-                'headers' => $this->requestHeaders,
-                'body' => $this->body,
-            ])->once()
-            ->andThrow($mockError);
-        $mockError->shouldReceive('getResponse')
-            ->once()->andReturn($mockResponse);
-        $mockResponse->shouldReceive('getStatusCode')
-            ->once()->andReturn(401);
         $this->cache->shouldReceive('clearAccessToken')->once();
+
+        // It gets a new access token
+        $this->mockGetAccessTokenCacheKey();
+        $this->request->shouldReceive('setAccessToken')
+            ->once()->andReturn($this->request);
+        // It makes another request
+        $this->mockMakeRequest();
 
         // Mock the response succeeding on the retry
         $this->client->shouldReceive('request')
@@ -243,32 +233,30 @@ class LtiServiceConnectorTest extends TestCase
             'body' => $this->responseBody,
         ];
 
+        // It gets an access token
+        $this->mockCacheHasAccessToken();
+        // It sets it on the request
         $this->request->shouldReceive('setAccessToken')
             ->once()->andReturn($this->request);
-        $this->request->shouldReceive('getMethod')
-            ->once()->andReturn($this->method);
-        $this->request->shouldReceive('getUrl')
-            ->once()->andReturn($this->url);
-        $this->request->shouldReceive('getPayload')
-            ->once()->andReturn($this->requestPayload);
+        // It makes the request
+        $this->mockMakeRequest();
 
+        // The request fails
+        $this->mockRequestReturnsA401();
+
+        // It clears the access token from the cache
         $this->mockCacheHasAccessToken();
-
-        // Mock the response failing twice
-        $mockError = Mockery::mock(ClientException::class);
-        $mockResponse = Mockery::mock(ResponseInterface::class);
-        $this->client->shouldReceive('request')
-            ->with($this->method, $this->url, [
-                'headers' => $this->requestHeaders,
-                'body' => $this->body,
-            ])->twice()
-            ->andThrow($mockError);
-        $mockError->shouldReceive('getResponse')
-            ->twice()->andReturn($mockResponse);
-        $mockResponse->shouldReceive('getStatusCode')
-            ->twice()->andReturn(401);
-
         $this->cache->shouldReceive('clearAccessToken')->once();
+
+        // It gets a new access token
+        $this->mockGetAccessTokenCacheKey();
+        $this->request->shouldReceive('setAccessToken')
+            ->once()->andReturn($this->request);
+        // It makes another request
+        $this->mockMakeRequest();
+
+        // The request fails again
+        $this->mockRequestReturnsA401();
 
         $this->expectException(ClientException::class);
 
@@ -288,41 +276,85 @@ class LtiServiceConnectorTest extends TestCase
         $responseBody = json_encode([$key => $lineitems]);
         $expected = array_merge($lineitems, $lineitems);
 
+        // Sets the access token on two requests
+        $this->registration->shouldReceive('getClientId')
+            ->twice()->andReturn('client_id');
+        $this->registration->shouldReceive('getIssuer')
+            ->twice()->andReturn('issuer');
+        $this->cache->shouldReceive('getAccessToken')
+            ->twice()->andReturn($this->token);
         $this->request->shouldReceive('setAccessToken')
-            ->once()->andReturn($this->request);
+            ->twice()->andReturn($this->request);
+
+        // Makes two requests, but gets the method and URL once before making the request
         $this->request->shouldReceive('getMethod')
-            ->twice()->andReturn($method);
+            ->times(3)->andReturn($method);
         $this->request->shouldReceive('getUrl')
-            ->twice()->andReturn($this->url);
+            ->times(3)->andReturn($this->url);
         $this->request->shouldReceive('getPayload')
             ->twice()->andReturn($this->requestPayload);
+        // Doesn't find a matching link in on the second header, so only updates the URL once
         $this->request->shouldReceive('setUrl')
             ->once()->andReturn($this->request);
 
-        $this->mockCacheHasAccessToken();
+        // Two responses come back
         $this->client->shouldReceive('request')
             ->with($method, $this->url, $this->requestPayload)
             ->twice()->andReturn($this->response);
-        $this->response->shouldReceive('getHeaders')
-            ->once()->andReturn($firstResponseHeaders);
-        $this->response->shouldReceive('getHeaders')
-            ->once()->andReturn($this->responseHeaders);
         $this->response->shouldReceive('getBody')
             ->twice()->andReturn($responseBody);
         $this->response->shouldReceive('getStatusCode')
             ->twice()->andReturn($this->responseStatus);
+        // The first has a Link header
+        $this->response->shouldReceive('getHeaders')
+            ->once()->andReturn($firstResponseHeaders);
+        // The second doesnt
+        $this->response->shouldReceive('getHeaders')
+            ->once()->andReturn($this->responseHeaders);
 
         $result = $this->connector->getAll($this->registration, $this->scopes, $this->request, $key);
 
         $this->assertEquals($expected, $result);
     }
 
-    private function mockCacheHasAccessToken()
+    private function mockMakeRequest()
+    {
+        // It makes another request
+        $this->request->shouldReceive('getMethod')
+            ->once()->andReturn($this->method);
+        $this->request->shouldReceive('getUrl')
+            ->once()->andReturn($this->url);
+        $this->request->shouldReceive('getPayload')
+            ->once()->andReturn($this->requestPayload);
+    }
+
+    private function mockRequestReturnsA401()
+    {
+        $mockError = Mockery::mock(ClientException::class);
+        $mockResponse = Mockery::mock(ResponseInterface::class);
+        $mockError->shouldReceive('getResponse')
+            ->once()->andReturn($mockResponse);
+        $mockResponse->shouldReceive('getStatusCode')
+            ->once()->andReturn(401);
+        $this->client->shouldReceive('request')
+            ->with($this->method, $this->url, [
+                'headers' => $this->requestHeaders,
+                'body' => $this->body,
+            ])->once()
+            ->andThrow($mockError);
+    }
+
+    private function mockGetAccessTokenCacheKey()
     {
         $this->registration->shouldReceive('getClientId')
             ->once()->andReturn('client_id');
         $this->registration->shouldReceive('getIssuer')
             ->once()->andReturn('issuer');
+    }
+
+    private function mockCacheHasAccessToken()
+    {
+        $this->mockGetAccessTokenCacheKey();
         $this->cache->shouldReceive('getAccessToken')
             ->once()->andReturn($this->token);
     }

--- a/tests/MessageValidators/DeepLinkMessageValidatorTest.php
+++ b/tests/MessageValidators/DeepLinkMessageValidatorTest.php
@@ -3,7 +3,7 @@
 namespace Tests\MessageValidators;
 
 use Packback\Lti1p3\MessageValidators\DeepLinkMessageValidator;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 class DeepLinkMessageValidatorTest extends TestCase
 {

--- a/tests/MessageValidators/ResourceMessageValidatorTest.php
+++ b/tests/MessageValidators/ResourceMessageValidatorTest.php
@@ -3,7 +3,7 @@
 namespace Tests\MessageValidators;
 
 use Packback\Lti1p3\MessageValidators\ResourceMessageValidator;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 class ResourceMessageValidatorTest extends TestCase
 {

--- a/tests/MessageValidators/SubmissionReviewMessageValidatorTest.php
+++ b/tests/MessageValidators/SubmissionReviewMessageValidatorTest.php
@@ -3,7 +3,7 @@
 namespace Tests\MessageValidators;
 
 use Packback\Lti1p3\MessageValidators\SubmissionReviewMessageValidator;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 class SubmissionReviewMessageValidatorTest extends TestCase
 {

--- a/tests/RedirectTest.php
+++ b/tests/RedirectTest.php
@@ -3,7 +3,6 @@
 namespace Tests;
 
 use Packback\Lti1p3\Redirect;
-use PHPUnit\Framework\TestCase;
 
 class RedirectTest extends TestCase
 {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests;
+
+use Mockery;
+use PHPUnit\Framework\TestCase as PHPUnitTestCase;
+
+class TestCase extends PHPUnitTestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+    }
+}


### PR DESCRIPTION
## Summary of Changes

This dries up the code for LTI Services fetching a collection of items. Similar code was duplicated across all 3 services, so this centralizes it in the ServiceConnector.

It also makes some package updates: the newest version of PHP-CS-Fixer and the correct guzzle package :man_facepalming: 

## Testing

<!-- Describe how this PR has been tested, manually and automatically. -->

- [x] I have run `composer test`
- [x] I have run `composer lint-fix`

This PR uses this branch on the platform :https://github.com/packbackbooks/questions/pull/4938. I've manually tested GBS and NRPS to verify they work.
