### PR TITLE
Fix PHP notice that results from attempted access to uncached access …

### DIFF
--- a/src/ImsStorage/ImsCache.php
+++ b/src/ImsStorage/ImsCache.php
@@ -53,7 +53,7 @@ class ImsCache implements ICache
     {
         $this->loadCache();
 
-        return $this->cache[$key];
+        return $this->cache[$key] ?? null;
     }
 
     public function clearAccessToken($key)


### PR DESCRIPTION
## Summary of Changes

LtiServiceConnector.php line 34 attempts to retrieve an access token from the cache, and then store it back to the cache if it is not already there. This is triggering a PHP notice:

PHP Notice:  Undefined index: [...remove...] in /.../vendor/packbackbooks/lti-1p3-tool/src/ImsStorage/ImsCache.php on line 56

This update simply tests whether the cache key is set and returns false if it's not already stored, similar to other functions in ImsCache.php

## Testing

Manually tested.