### PR TITLE
Fix fetching of line items and eliminate a PHP warning for missing key

### DIFF
--- a/src/LtiAbstractService.php
+++ b/src/LtiAbstractService.php
@@ -45,7 +45,7 @@ abstract class LtiAbstractService
         );
     }
 
-    protected function getAll(IServiceRequest $request, string $key): array
+    protected function getAll(IServiceRequest $request, string $key = null): array
     {
         return $this->serviceConnector->getAll(
             $this->registration,

--- a/src/LtiAssignmentsGradesService.php
+++ b/src/LtiAssignmentsGradesService.php
@@ -48,19 +48,11 @@ class LtiAssignmentsGradesService extends LtiAbstractService
         $lineitems = $this->getLineItems();
 
         foreach ($lineitems as $lineitem) {
-            if (
-                (empty($newLineItem->getResourceId()) && empty($newLineItem->getResourceLinkId())) ||
-                (isset($lineitem['resourceId']) && $lineitem['resourceId'] == $newLineItem->getResourceId()) ||
-                (isset($lineitem['resourceLinkId']) && $lineitem['resourceLinkId'] == $newLineItem->getResourceLinkId())
-            ) {
-                if (
-                    empty($newLineItem->getTag()) ||
-                    (isset($lineitem['tag']) && $lineitem['tag'] == $newLineItem->getTag())
-                ) {
-                    return new LtiLineitem($lineitem);
-                }
+            if ($this->isMatchingLineitem($lineitem, $newLineItem)) {
+                return new LtiLineitem($lineitem);
             }
         }
+
         $request = new ServiceRequest(LtiServiceConnector::METHOD_POST, $this->getServiceData()['lineitems']);
         $request->setBody($newLineItem)
             ->setContentType(static::CONTENTTYPE_LINEITEM)
@@ -103,5 +95,13 @@ class LtiAssignmentsGradesService extends LtiAbstractService
         }
 
         return $lineitems;
+    }
+
+    private function isMatchingLineitem(array $lineitem, LtiLineitem $newLineItem): bool
+    {
+        if (($lineitem['tag'] ?? null) != $newLineItem->getTag()) { return false; }
+        if (($lineitem['resourceId'] ?? null) != $newLineItem->getResourceId()) { return false; }
+        if (($lineitem['resourceLinkId'] ?? null) != $newLineItem->getResourceLinkId()) { return false; }
+        return true;
     }
 }

--- a/src/LtiAssignmentsGradesService.php
+++ b/src/LtiAssignmentsGradesService.php
@@ -6,6 +6,7 @@ class LtiAssignmentsGradesService extends LtiAbstractService
 {
     public const CONTENTTYPE_SCORE = 'application/vnd.ims.lis.v1.score+json';
     public const CONTENTTYPE_LINEITEM = 'application/vnd.ims.lis.v2.lineitem+json';
+    public const CONTENTTYPE_LINEITEMCONTAINER = 'application/vnd.ims.lis.v2.lineitemcontainer+json';
     public const CONTENTTYPE_RESULTCONTAINER = 'application/vnd.ims.lis.v2.resultcontainer+json';
 
     public function getScope(): array
@@ -52,7 +53,10 @@ class LtiAssignmentsGradesService extends LtiAbstractService
                 (isset($lineitem['resourceId']) && $lineitem['resourceId'] == $newLineItem->getResourceId()) ||
                 (isset($lineitem['resourceLinkId']) && $lineitem['resourceLinkId'] == $newLineItem->getResourceLinkId())
             ) {
-                if (empty($newLineItem->getTag()) || $lineitem['tag'] == $newLineItem->getTag()) {
+                if (
+                    empty($newLineItem->getTag()) ||
+                    (isset($lineitem['tag']) && $lineitem['tag'] == $newLineItem->getTag())
+                ) {
                     return new LtiLineitem($lineitem);
                 }
             }
@@ -89,9 +93,9 @@ class LtiAssignmentsGradesService extends LtiAbstractService
             LtiServiceConnector::METHOD_GET,
             $this->getServiceData()['lineitems']
         );
-        $request->setAccept(static::CONTENTTYPE_RESULTCONTAINER);
+        $request->setAccept(static::CONTENTTYPE_LINEITEMCONTAINER);
 
-        $lineitems = $this->getAll($request, 'lineitems');
+        $lineitems = $this->getAll($request);
 
         // If there is only one item, then wrap it in an array so the foreach works
         if (isset($lineitems['body']['id'])) {

--- a/src/LtiAssignmentsGradesService.php
+++ b/src/LtiAssignmentsGradesService.php
@@ -99,9 +99,8 @@ class LtiAssignmentsGradesService extends LtiAbstractService
 
     private function isMatchingLineitem(array $lineitem, LtiLineitem $newLineItem): bool
     {
-        if (($lineitem['tag'] ?? null) != $newLineItem->getTag()) { return false; }
-        if (($lineitem['resourceId'] ?? null) != $newLineItem->getResourceId()) { return false; }
-        if (($lineitem['resourceLinkId'] ?? null) != $newLineItem->getResourceLinkId()) { return false; }
-        return true;
+        return $newLineItem->getTag() == ($lineitem['tag'] ?? null) &&
+            $newLineItem->getResourceId() == ($lineitem['resourceId'] ?? null) &&
+            $newLineItem->getResourceLinkId() == ($lineitem['resourceLinkId'] ?? null);
     }
 }

--- a/src/LtiServiceConnector.php
+++ b/src/LtiServiceConnector.php
@@ -136,7 +136,7 @@ class LtiServiceConnector implements ILtiServiceConnector
         ILtiRegistration $registration,
         array $scopes,
         IServiceRequest $request,
-        string $key
+        string $key = null
     ): array {
         if ($request->getMethod() !== static::METHOD_GET) {
             throw new \Exception('An invalid method was specified by an LTI service requesting all items.');
@@ -148,7 +148,8 @@ class LtiServiceConnector implements ILtiServiceConnector
         while ($nextUrl) {
             $response = $this->makeServiceRequest($registration, $scopes, $request);
 
-            $results = array_merge($results, $response['body'][$key] ?? []);
+            $page_results = $key === null ? ($response['body'] ?? []) : ($response['body'][$key] ?? []);
+            $results = array_merge($results, $page_results);
 
             $nextUrl = $this->getNextUrl($response['headers']);
             if ($nextUrl) {


### PR DESCRIPTION
## Summary of Changes

I couldn't get getLineItems() to return any data, and findOrCreateLineItem() was creating new line items constantly. It looks like the line items are actually returned into $response['body'] and not $response['body']['lineitems'], and this is backed up by the original PHP library and the Python library in these files:

https://github.com/IMSGlobal/lti-1-3-php-library/blob/master/src/lti/LTI_Assignments_Grades_Service.php
https://github.com/dmitry-viskov/pylti1.3/blob/master/pylti1p3/assignments_grades.py

Additionally, the 'tag' key was not being isset() tested like the other fields in findOrCreateLineitem() and so was producing a warning in PHP logs if the tag was not set in a returned line item.

## Testing

Manual testing that shows the line items are now being returned from Canvas LMS.

I am wondering how this regression has occurred from the library it was forked from, and whether this code is being used in any production Canvas LTI tool integrations? I really appreciate all the work on it, just wondering how production-ready this code is. Does this return behavior differ by LMS systems and some do return it in the 'lineitems' key of the response? Thanks!
