### PR TITLE
Include resourceLinkId attribute when creating line item

### DIFF
--- a/src/LtiLineitem.php
+++ b/src/LtiLineitem.php
@@ -33,6 +33,7 @@ class LtiLineitem
             'scoreMaximum' => $this->score_maximum,
             'label' => $this->label,
             'resourceId' => $this->resource_id,
+            'resourceLinkId' => $this->resource_link_id,
             'tag' => $this->tag,
             'startDateTime' => $this->start_date_time,
             'endDateTime' => $this->end_date_time,

--- a/tests/LtiLineitemTest.php
+++ b/tests/LtiLineitemTest.php
@@ -182,6 +182,7 @@ class LtiLineitemTest extends TestCase
             'scoreMaximum' => 'ScoreMaximum',
             'label' => 'Label',
             'resourceId' => 'ResourceId',
+            'resourceLinkId' => 'ResourceLinkId',
             'tag' => 'Tag',
             'startDateTime' => 'StartDateTime',
             'endDateTime' => 'EndDateTime',


### PR DESCRIPTION
## Summary of Changes

Resource link id was not being sent in requests to create a line item. You can see that this field is documented here:

https://www.imsglobal.org/spec/lti-ags/v2p0#resourcelinkid-and-binding-a-line-item-to-a-resource-link
https://canvas.instructure.com/doc/api/line_items.html

## Testing

Manual testing in Canvas LMS
