### PR TITLE
PODB-266 Get the public keyset via a client instead of file_get_contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.1.1
+
+* Updated `LtiMessageLaunch` to fetch JWKs via an HTTP client instead of `file_get_contents()`. ([#38](https://github.com/packbackbooks/lti-1-3-php-library/pull/38))
+* Added a new method to `ILtiServiceConnector`: `makeRequest()`. ([#38](https://github.com/packbackbooks/lti-1-3-php-library/pull/38))
+
 ## 4.1.0
 
 * Allowed `getGrades()` to be called without a line item. ([#34](https://github.com/packbackbooks/lti-1-3-php-library/pull/34))
@@ -10,7 +15,7 @@
 
 ## 3.0.3
 
-* Added response/request logging to LtiServiceConnector. ([#31](https://github.com/packbackbooks/lti-1-3-php-library/pull/31))
+* Added response/request logging to `LtiServiceConnector`. ([#31](https://github.com/packbackbooks/lti-1-3-php-library/pull/31))
 
 Note: Upgrade to 4.0.0 for this logging to be disabled by default.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 4.1.1
 
 * Updated `LtiMessageLaunch` to fetch JWKs via an HTTP client instead of `file_get_contents()`. ([#38](https://github.com/packbackbooks/lti-1-3-php-library/pull/38))
-* Added a new method to `ILtiServiceConnector`: `makeRequest()`. ([#38](https://github.com/packbackbooks/lti-1-3-php-library/pull/38))
+* Added new methods to `ILtiServiceConnector`: `makeRequest()`, `getRequestBody()`. ([#38](https://github.com/packbackbooks/lti-1-3-php-library/pull/38))
 
 ## 4.1.0
 

--- a/UPGRADES.md
+++ b/UPGRADES.md
@@ -6,6 +6,7 @@ Version 4.0 introduced changes to the `Packback\Lti1p3\Interfaces\ILtiServiceCon
 
 - `setDebuggingMode()`
 - `makeRequest()`
+- `getRequestBody()`
 
 ## 2.0 to 3.0
 

--- a/UPGRADES.md
+++ b/UPGRADES.md
@@ -2,7 +2,10 @@
 
 ### New method implemented on the `ILtiServiceConnector`
 
-Version 4.0 introduced changes to the `Packback\Lti1p3\Interfaces\ILtiServiceConnector` interface, adding one method: `setDebuggingMode()`.
+Version 4.0 introduced changes to the `Packback\Lti1p3\Interfaces\ILtiServiceConnector` interface, the following methods:
+
+- `setDebuggingMode()`
+- `makeRequest()`
 
 ## 2.0 to 3.0
 

--- a/UPGRADES.md
+++ b/UPGRADES.md
@@ -13,11 +13,11 @@ Version 4.0 introduced changes to the `Packback\Lti1p3\Interfaces\ILtiServiceCon
 
 Version 3.0 introduced changes to the `Packback\Lti1p3\Interfaces\ICache` interface, adding one method: `clearAccessToken()`. This method must be implemented to any custom implementations of the interface. The [Laravel Implementation Guide](https://github.com/packbackbooks/lti-1-3-php-library/wiki/Laravel-Implementation-Guide#cache) contains an example.
 
-### Using GuzzleHttp\Client instead of curl
+### Using `GuzzleHttp\Client` instead of curl
 
 The `Packback\Lti1p3\LtiServiceConnector` now uses Guzzle instead of curl to make requests. This puts control of this client and its configuration in the hands of the developer. The section below contains information on implementing this change.
 
-### Changes to the LtiServiceConnector and LTI services
+### Changes to the `LtiServiceConnector` and LTI services
 
 The implementation of the `Packback\Lti1p3\LtiServiceConnector` changed to act as a general API Client for the various LTI service (Assignment Grades, Names Roles Provisioning, etc.) Specifically, the constructor for the following classes now accept different arguments:
 

--- a/UPGRADES.md
+++ b/UPGRADES.md
@@ -1,8 +1,8 @@
 ## 3.0 to 4.0
 
-### New method implemented on the `ILtiServiceConnector`
+### New methods implemented on the `ILtiServiceConnector`
 
-Version 4.0 introduced changes to the `Packback\Lti1p3\Interfaces\ILtiServiceConnector` interface, the following methods:
+Version 4.0 introduced changes to the `Packback\Lti1p3\Interfaces\ILtiServiceConnector` interface, adding the following methods:
 
 - `setDebuggingMode()`
 - `makeRequest()`

--- a/src/Interfaces/ILtiServiceConnector.php
+++ b/src/Interfaces/ILtiServiceConnector.php
@@ -2,13 +2,15 @@
 
 namespace Packback\Lti1p3\Interfaces;
 
+use GuzzleHttp\Psr7\Response;
+
 interface ILtiServiceConnector
 {
     public function getAccessToken(ILtiRegistration $registration, array $scopes);
 
-    public function makeRequest(
-        IServiceRequest $request
-    );
+    public function makeRequest(IServiceRequest $request);
+
+    public function getResponseBody(Response $request): array;
 
     public function makeServiceRequest(
         ILtiRegistration $registration,

--- a/src/Interfaces/ILtiServiceConnector.php
+++ b/src/Interfaces/ILtiServiceConnector.php
@@ -6,6 +6,10 @@ interface ILtiServiceConnector
 {
     public function getAccessToken(ILtiRegistration $registration, array $scopes);
 
+    public function makeRequest(
+        IServiceRequest $request
+    );
+
     public function makeServiceRequest(
         ILtiRegistration $registration,
         array $scopes,

--- a/src/LtiMessageLaunch.php
+++ b/src/LtiMessageLaunch.php
@@ -270,7 +270,7 @@ class LtiMessageLaunch
 
         // Download key set
         $response = $this->serviceConnector->makeRequest($request);
-        $publicKeySet = $response->getBody();
+        $publicKeySet = LtiServiceConnector::getResponseBody($response);
 
         if (empty($publicKeySet)) {
             // Failed to fetch public keyset from URL.

--- a/src/LtiMessageLaunch.php
+++ b/src/LtiMessageLaunch.php
@@ -6,6 +6,7 @@ use Firebase\JWT\ExpiredException;
 use Firebase\JWT\JWK;
 use Firebase\JWT\JWT;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
 use Packback\Lti1p3\Interfaces\ICache;
 use Packback\Lti1p3\Interfaces\ICookie;
 use Packback\Lti1p3\Interfaces\IDatabase;
@@ -269,8 +270,12 @@ class LtiMessageLaunch
         $request = new ServiceRequest(LtiServiceConnector::METHOD_GET, $keySetUrl);
 
         // Download key set
-        $response = $this->serviceConnector->makeRequest($request);
-        $publicKeySet = LtiServiceConnector::getResponseBody($response);
+        try {
+            $response = $this->serviceConnector->makeRequest($request);
+        } catch (ClientException $e) {
+            throw new LtiException(static::ERR_NO_PUBLIC_KEY);
+        }
+        $publicKeySet = $this->serviceConnector->getResponseBody($response);
 
         if (empty($publicKeySet)) {
             // Failed to fetch public keyset from URL.

--- a/src/LtiMessageLaunch.php
+++ b/src/LtiMessageLaunch.php
@@ -6,7 +6,7 @@ use Firebase\JWT\ExpiredException;
 use Firebase\JWT\JWK;
 use Firebase\JWT\JWT;
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\TransferException;
 use Packback\Lti1p3\Interfaces\ICache;
 use Packback\Lti1p3\Interfaces\ICookie;
 use Packback\Lti1p3\Interfaces\IDatabase;

--- a/src/LtiMessageLaunch.php
+++ b/src/LtiMessageLaunch.php
@@ -272,7 +272,7 @@ class LtiMessageLaunch
         // Download key set
         try {
             $response = $this->serviceConnector->makeRequest($request);
-        } catch (ClientException $e) {
+        } catch (TransferException $e) {
             throw new LtiException(static::ERR_NO_PUBLIC_KEY);
         }
         $publicKeySet = $this->serviceConnector->getResponseBody($response);

--- a/src/LtiMessageLaunch.php
+++ b/src/LtiMessageLaunch.php
@@ -265,18 +265,19 @@ class LtiMessageLaunch
 
     private function getPublicKey()
     {
-        $key_set_url = $this->registration->getKeySetUrl();
+        $keySetUrl = $this->registration->getKeySetUrl();
+        $request = new ServiceRequest(LtiServiceConnector::METHOD_GET, $keySetUrl);
 
         // Download key set
-        $public_key_set = json_decode(file_get_contents($key_set_url), true);
+        $publicKeySet = $this->serviceConnector->makeRequest($request);
 
-        if (empty($public_key_set)) {
+        if (empty($publicKeySet)) {
             // Failed to fetch public keyset from URL.
             throw new LtiException(static::ERR_FETCH_PUBLIC_KEY);
         }
 
         // Find key used to sign the JWT (matches the KID in the header)
-        foreach ($public_key_set['keys'] as $key) {
+        foreach ($publicKeySet['keys'] as $key) {
             if ($key['kid'] == $this->jwt['header']['kid']) {
                 try {
                     return openssl_pkey_get_details(

--- a/src/LtiMessageLaunch.php
+++ b/src/LtiMessageLaunch.php
@@ -269,7 +269,8 @@ class LtiMessageLaunch
         $request = new ServiceRequest(LtiServiceConnector::METHOD_GET, $keySetUrl);
 
         // Download key set
-        $publicKeySet = $this->serviceConnector->makeRequest($request);
+        $response = $this->serviceConnector->makeRequest($request);
+        $publicKeySet = $response->getBody();
 
         if (empty($publicKeySet)) {
             // Failed to fetch public keyset from URL.

--- a/src/LtiServiceConnector.php
+++ b/src/LtiServiceConnector.php
@@ -80,6 +80,15 @@ class LtiServiceConnector implements ILtiServiceConnector
         return $tokenData['access_token'];
     }
 
+    public function makeRequest(IServiceRequest $request)
+    {
+        return $this->client->request(
+            $request->getMethod(),
+            $request->getUrl(),
+            $request->getPayload()
+        );
+    }
+
     public function makeServiceRequest(
         ILtiRegistration $registration,
         array $scopes,
@@ -89,11 +98,7 @@ class LtiServiceConnector implements ILtiServiceConnector
         $request->setAccessToken($this->getAccessToken($registration, $scopes));
 
         try {
-            $response = $this->client->request(
-                $request->getMethod(),
-                $request->getUrl(),
-                $request->getPayload()
-            );
+            $response = $this->makeRequest($request);
         } catch (ClientException $e) {
             $status = $e->getResponse()->getStatusCode();
 

--- a/src/LtiServiceConnector.php
+++ b/src/LtiServiceConnector.php
@@ -72,7 +72,7 @@ class LtiServiceConnector implements ILtiServiceConnector
             'form_params' => $authRequest,
         ]);
 
-        $tokenData = static::getResponseBody($response);
+        $tokenData = $this->getResponseBody($response);
 
         // Cache access token
         $this->cache->cacheAccessToken($accessTokenKey, $tokenData['access_token']);
@@ -89,9 +89,10 @@ class LtiServiceConnector implements ILtiServiceConnector
         );
     }
 
-    public static function getResponseBody(Response $response): array
+    public function getResponseBody(Response $response): array
     {
         $responseBody = (string) $response->getBody();
+
         return json_decode($responseBody, true);
     }
 
@@ -123,7 +124,7 @@ class LtiServiceConnector implements ILtiServiceConnector
         array_walk($responseHeaders, function (&$value) {
             $value = $value[0];
         });
-        $responseBody = static::getResponseBody($response);
+        $responseBody = $this->getResponseBody($response);
 
         if ($this->debuggingMode) {
             error_log('Syncing grade for this lti_user_id: '.

--- a/src/ServiceRequest.php
+++ b/src/ServiceRequest.php
@@ -6,11 +6,12 @@ use Packback\Lti1p3\Interfaces\IServiceRequest;
 
 class ServiceRequest implements IServiceRequest
 {
-    public $method;
-    public $url;
-    public $body;
-    public $contentType = 'application/json';
-    public $accept = 'application/json';
+    private $method;
+    private $url;
+    private $body;
+    private $accessToken;
+    private $contentType = 'application/json';
+    private $accept = 'application/json';
 
     public function __construct(string $method, string $url)
     {
@@ -80,9 +81,12 @@ class ServiceRequest implements IServiceRequest
     private function getHeaders(): array
     {
         $headers = [
-            'Authorization' => $this->accessToken,
             'Accept' => $this->accept,
         ];
+        
+        if (isset($this->accessToken)) {
+            $headers['Authorization'] = $this->accessToken;
+        }
 
         if ($this->getMethod() === LtiServiceConnector::METHOD_POST) {
             $headers['Content-Type'] = $this->contentType;

--- a/src/ServiceRequest.php
+++ b/src/ServiceRequest.php
@@ -83,7 +83,7 @@ class ServiceRequest implements IServiceRequest
         $headers = [
             'Accept' => $this->accept,
         ];
-        
+
         if (isset($this->accessToken)) {
             $headers['Authorization'] = $this->accessToken;
         }

--- a/tests/Certification/Lti13CertificationTest.php
+++ b/tests/Certification/Lti13CertificationTest.php
@@ -4,6 +4,7 @@ namespace Certification;
 
 use Carbon\Carbon;
 use Firebase\JWT\JWT;
+use GuzzleHttp\Psr7\Response;
 use Mockery;
 use Packback\Lti1p3\Interfaces\ICache;
 use Packback\Lti1p3\Interfaces\ICookie;
@@ -348,12 +349,12 @@ class Lti13CertificationTest extends TestCase
         $casesCount = count($testCases);
         $testedCases = 0;
 
-        $request = Mockery::mock();
+        $request = Mockery::mock(Response::class);
         $this->serviceConnector->shouldReceive('makeRequest')
             // All but one invalid cert case get the JWK
             ->times($casesCount - 1)
             ->andReturn($request);
-        $request->shouldReceive('getBody')
+        $this->serviceConnector->shouldReceive('getResponseBody')
             ->times($casesCount - 1)
             ->andReturn(json_decode(file_get_contents(static::JWKS_FILE), true));
 
@@ -452,10 +453,10 @@ class Lti13CertificationTest extends TestCase
                 'state' => static::STATE,
             ];
 
-            $request = Mockery::mock();
+            $request = Mockery::mock(Response::class);
             $this->serviceConnector->shouldReceive('makeRequest')
                 ->once()->andReturn($request);
-            $request->shouldReceive('getBody')
+            $this->serviceConnector->shouldReceive('getResponseBody')
                 ->once()->andReturn(json_decode(file_get_contents(static::JWKS_FILE), true));
 
             $result = LtiMessageLaunch::new($this->db, $this->cache, $this->cookie, $this->serviceConnector)
@@ -492,10 +493,10 @@ class Lti13CertificationTest extends TestCase
             'state' => static::STATE,
         ];
 
-        $request = Mockery::mock();
+        $request = Mockery::mock(Response::class);
         $this->serviceConnector->shouldReceive('makeRequest')
             ->once()->andReturn($request);
-        $request->shouldReceive('getBody')
+        $this->serviceConnector->shouldReceive('getResponseBody')
             ->once()->andReturn(json_decode(file_get_contents(static::JWKS_FILE), true));
 
         return LtiMessageLaunch::new($this->db, $this->cache, $this->cookie, $this->serviceConnector)

--- a/tests/Certification/Lti13CertificationTest.php
+++ b/tests/Certification/Lti13CertificationTest.php
@@ -4,9 +4,11 @@ namespace Certification;
 
 use Carbon\Carbon;
 use Firebase\JWT\JWT;
+use Mockery;
 use Packback\Lti1p3\Interfaces\ICache;
 use Packback\Lti1p3\Interfaces\ICookie;
 use Packback\Lti1p3\Interfaces\IDatabase;
+use Packback\Lti1p3\Interfaces\ILtiServiceConnector;
 use Packback\Lti1p3\JwksEndpoint;
 use Packback\Lti1p3\LtiConstants;
 use Packback\Lti1p3\LtiDeployment;
@@ -217,6 +219,7 @@ class Lti13CertificationTest extends TestCase
             LtiOidcLogin::COOKIE_PREFIX.static::STATE,
             static::STATE
         );
+        $this->serviceConnector = Mockery::mock(ILtiServiceConnector::class);
     }
 
     public function buildJWT($data, $header)
@@ -345,6 +348,11 @@ class Lti13CertificationTest extends TestCase
         $casesCount = count($testCases);
         $testedCases = 0;
 
+        $this->serviceConnector->shouldReceive('makeRequest')
+            // All but one invalid cert case get the JWK
+            ->times($casesCount - 1)
+            ->andReturn(json_decode(file_get_contents(static::JWKS_FILE), true));
+
         foreach ($testCases as $testCase) {
             $testCaseDir = $testCasesDir.DIRECTORY_SEPARATOR.$testCase.DIRECTORY_SEPARATOR;
 
@@ -391,7 +399,7 @@ class Lti13CertificationTest extends TestCase
             ];
 
             try {
-                LtiMessageLaunch::new($this->db, $this->cache, $this->cookie)
+                LtiMessageLaunch::new($this->db, $this->cache, $this->cookie, $this->serviceConnector)
                     ->validate($params);
             } catch (\Exception $e) {
                 $this->assertInstanceOf(LtiException::class, $e);
@@ -440,7 +448,10 @@ class Lti13CertificationTest extends TestCase
                 'state' => static::STATE,
             ];
 
-            $result = LtiMessageLaunch::new($this->db, $this->cache, $this->cookie)
+            $this->serviceConnector->shouldReceive('makeRequest')
+                ->once()->andReturn(json_decode(file_get_contents(static::JWKS_FILE), true));
+
+            $result = LtiMessageLaunch::new($this->db, $this->cache, $this->cookie, $this->serviceConnector)
                 ->validate($params);
 
             // Assertions
@@ -474,7 +485,10 @@ class Lti13CertificationTest extends TestCase
             'state' => static::STATE,
         ];
 
-        return LtiMessageLaunch::new($this->db, $this->cache, $this->cookie)
+        $this->serviceConnector->shouldReceive('makeRequest')
+            ->once()->andReturn(json_decode(file_get_contents(static::JWKS_FILE), true));
+
+        return LtiMessageLaunch::new($this->db, $this->cache, $this->cookie, $this->serviceConnector)
             ->validate($params);
     }
 }

--- a/tests/Certification/Lti13CertificationTest.php
+++ b/tests/Certification/Lti13CertificationTest.php
@@ -348,8 +348,12 @@ class Lti13CertificationTest extends TestCase
         $casesCount = count($testCases);
         $testedCases = 0;
 
+        $request = Mockery::mock();
         $this->serviceConnector->shouldReceive('makeRequest')
             // All but one invalid cert case get the JWK
+            ->times($casesCount - 1)
+            ->andReturn($request);
+        $request->shouldReceive('getBody')
             ->times($casesCount - 1)
             ->andReturn(json_decode(file_get_contents(static::JWKS_FILE), true));
 
@@ -448,7 +452,10 @@ class Lti13CertificationTest extends TestCase
                 'state' => static::STATE,
             ];
 
+            $request = Mockery::mock();
             $this->serviceConnector->shouldReceive('makeRequest')
+                ->once()->andReturn($request);
+            $request->shouldReceive('getBody')
                 ->once()->andReturn(json_decode(file_get_contents(static::JWKS_FILE), true));
 
             $result = LtiMessageLaunch::new($this->db, $this->cache, $this->cookie, $this->serviceConnector)
@@ -485,7 +492,10 @@ class Lti13CertificationTest extends TestCase
             'state' => static::STATE,
         ];
 
+        $request = Mockery::mock();
         $this->serviceConnector->shouldReceive('makeRequest')
+            ->once()->andReturn($request);
+        $request->shouldReceive('getBody')
             ->once()->andReturn(json_decode(file_get_contents(static::JWKS_FILE), true));
 
         return LtiMessageLaunch::new($this->db, $this->cache, $this->cookie, $this->serviceConnector)

--- a/tests/LtiMessageLaunchTest.php
+++ b/tests/LtiMessageLaunchTest.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use Carbon\Carbon;
 use Firebase\JWT\JWT;
+use GuzzleHttp\Psr7\Response;
 use Mockery;
 use Packback\Lti1p3\Interfaces\ICache;
 use Packback\Lti1p3\Interfaces\ICookie;
@@ -179,10 +180,9 @@ class LtiMessageLaunchTest extends TestCase
             ->once()->andReturn($this->issuer['client_id']);
         $this->registration->shouldReceive('getKeySetUrl')
             ->once()->andReturn($this->issuer['key_set_url']);
-        $request = Mockery::mock();
         $this->serviceConnector->shouldReceive('makeRequest')
-            ->once()->andReturn($request);
-        $request->shouldReceive('getBody')
+            ->once()->andReturn(Mockery::mock(Response::class));
+        $this->serviceConnector->shouldReceive('getResponseBody')
             ->once()->andReturn(json_decode(file_get_contents(static::JWKS_FILE), true));
         $this->database->shouldReceive('findDeployment')
             ->once()->andReturn(['a deployment']);
@@ -364,10 +364,9 @@ class LtiMessageLaunchTest extends TestCase
             ->once()->andReturn($this->payload['aud']);
         $this->registration->shouldReceive('getKeySetUrl')
             ->once()->andReturn($this->issuer['key_set_url']);
-        $request = Mockery::mock();
         $this->serviceConnector->shouldReceive('makeRequest')
-            ->once()->andReturn($request);
-        $request->shouldReceive('getBody')
+            ->once()->andReturn(Mockery::mock(Response::class));
+        $this->serviceConnector->shouldReceive('getResponseBody')
             ->once()->andReturn(json_decode(file_get_contents(static::JWKS_FILE), true));
 
         $this->expectException(LtiException::class);
@@ -394,10 +393,9 @@ class LtiMessageLaunchTest extends TestCase
             ->once()->andReturn($this->payload['aud']);
         $this->registration->shouldReceive('getKeySetUrl')
             ->once()->andReturn($this->issuer['key_set_url']);
-        $request = Mockery::mock();
         $this->serviceConnector->shouldReceive('makeRequest')
-            ->once()->andReturn($request);
-        $request->shouldReceive('getBody')
+            ->once()->andReturn(Mockery::mock(Response::class));
+        $this->serviceConnector->shouldReceive('getResponseBody')
             ->once()->andReturn(json_decode(file_get_contents(static::JWKS_FILE), true));
         $this->database->shouldReceive('findDeployment')
             ->once()->andReturn();

--- a/tests/LtiMessageLaunchTest.php
+++ b/tests/LtiMessageLaunchTest.php
@@ -179,7 +179,10 @@ class LtiMessageLaunchTest extends TestCase
             ->once()->andReturn($this->issuer['client_id']);
         $this->registration->shouldReceive('getKeySetUrl')
             ->once()->andReturn($this->issuer['key_set_url']);
+        $request = Mockery::mock();
         $this->serviceConnector->shouldReceive('makeRequest')
+            ->once()->andReturn($request);
+        $request->shouldReceive('getBody')
             ->once()->andReturn(json_decode(file_get_contents(static::JWKS_FILE), true));
         $this->database->shouldReceive('findDeployment')
             ->once()->andReturn(['a deployment']);
@@ -361,7 +364,10 @@ class LtiMessageLaunchTest extends TestCase
             ->once()->andReturn($this->payload['aud']);
         $this->registration->shouldReceive('getKeySetUrl')
             ->once()->andReturn($this->issuer['key_set_url']);
+        $request = Mockery::mock();
         $this->serviceConnector->shouldReceive('makeRequest')
+            ->once()->andReturn($request);
+        $request->shouldReceive('getBody')
             ->once()->andReturn(json_decode(file_get_contents(static::JWKS_FILE), true));
 
         $this->expectException(LtiException::class);
@@ -388,7 +394,10 @@ class LtiMessageLaunchTest extends TestCase
             ->once()->andReturn($this->payload['aud']);
         $this->registration->shouldReceive('getKeySetUrl')
             ->once()->andReturn($this->issuer['key_set_url']);
+        $request = Mockery::mock();
         $this->serviceConnector->shouldReceive('makeRequest')
+            ->once()->andReturn($request);
+        $request->shouldReceive('getBody')
             ->once()->andReturn(json_decode(file_get_contents(static::JWKS_FILE), true));
         $this->database->shouldReceive('findDeployment')
             ->once()->andReturn();

--- a/tests/LtiMessageLaunchTest.php
+++ b/tests/LtiMessageLaunchTest.php
@@ -179,6 +179,8 @@ class LtiMessageLaunchTest extends TestCase
             ->once()->andReturn($this->issuer['client_id']);
         $this->registration->shouldReceive('getKeySetUrl')
             ->once()->andReturn($this->issuer['key_set_url']);
+        $this->serviceConnector->shouldReceive('makeRequest')
+            ->once()->andReturn(json_decode(file_get_contents(static::JWKS_FILE), true));
         $this->database->shouldReceive('findDeployment')
             ->once()->andReturn(['a deployment']);
         $this->cache->shouldReceive('cacheLaunchData')
@@ -359,6 +361,8 @@ class LtiMessageLaunchTest extends TestCase
             ->once()->andReturn($this->payload['aud']);
         $this->registration->shouldReceive('getKeySetUrl')
             ->once()->andReturn($this->issuer['key_set_url']);
+        $this->serviceConnector->shouldReceive('makeRequest')
+            ->once()->andReturn(json_decode(file_get_contents(static::JWKS_FILE), true));
 
         $this->expectException(LtiException::class);
         $this->expectExceptionMessage(LtiMessageLaunch::ERR_MISSING_DEPLOYEMENT_ID);
@@ -384,6 +388,8 @@ class LtiMessageLaunchTest extends TestCase
             ->once()->andReturn($this->payload['aud']);
         $this->registration->shouldReceive('getKeySetUrl')
             ->once()->andReturn($this->issuer['key_set_url']);
+        $this->serviceConnector->shouldReceive('makeRequest')
+            ->once()->andReturn(json_decode(file_get_contents(static::JWKS_FILE), true));
         $this->database->shouldReceive('findDeployment')
             ->once()->andReturn();
 

--- a/tests/LtiServiceConnectorTest.php
+++ b/tests/LtiServiceConnectorTest.php
@@ -4,13 +4,14 @@ namespace Tests;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Psr7\Response;
 use Mockery;
 use Packback\Lti1p3\Interfaces\ICache;
 use Packback\Lti1p3\Interfaces\ILtiRegistration;
 use Packback\Lti1p3\Interfaces\IServiceRequest;
 use Packback\Lti1p3\LtiRegistration;
 use Packback\Lti1p3\LtiServiceConnector;
-use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 
 class LtiServiceConnectorTest extends TestCase
 {
@@ -41,7 +42,8 @@ class LtiServiceConnectorTest extends TestCase
         $this->request = Mockery::mock(IServiceRequest::class);
         $this->cache = Mockery::mock(ICache::class);
         $this->client = Mockery::mock(Client::class);
-        $this->response = Mockery::mock(ResponseInterface::class);
+        $this->response = Mockery::mock(Response::class);
+        $this->streamInterface = Mockery::mock(StreamInterface::class);
 
         $this->scopes = ['scopeKey'];
         $this->token = 'TokenOfAccess';
@@ -98,6 +100,8 @@ class LtiServiceConnectorTest extends TestCase
         $this->client->shouldReceive('post')
             ->once()->andReturn($this->response);
         $this->response->shouldReceive('getBody')
+            ->once()->andReturn($this->streamInterface);
+        $this->streamInterface->shouldReceive('__toString')
             ->once()->andReturn(json_encode(['access_token' => $this->token]));
         $this->cache->shouldReceive('cacheAccessToken')->once();
 
@@ -128,6 +132,8 @@ class LtiServiceConnectorTest extends TestCase
         $this->response->shouldReceive('getHeaders')
             ->once()->andReturn($this->responseHeaders);
         $this->response->shouldReceive('getBody')
+            ->once()->andReturn($this->streamInterface);
+        $this->streamInterface->shouldReceive('__toString')
             ->once()->andReturn(json_encode($this->responseBody));
         $this->response->shouldReceive('getStatusCode')
             ->once()->andReturn($this->responseStatus);
@@ -197,6 +203,8 @@ class LtiServiceConnectorTest extends TestCase
         $this->response->shouldReceive('getHeaders')
             ->once()->andReturn($this->responseHeaders);
         $this->response->shouldReceive('getBody')
+            ->once()->andReturn($this->streamInterface);
+        $this->streamInterface->shouldReceive('__toString')
             ->once()->andReturn(json_encode($this->responseBody));
         $this->response->shouldReceive('getStatusCode')
             ->once()->andReturn($this->responseStatus);
@@ -301,6 +309,8 @@ class LtiServiceConnectorTest extends TestCase
             ->with($method, $this->url, $this->requestPayload)
             ->twice()->andReturn($this->response);
         $this->response->shouldReceive('getBody')
+            ->twice()->andReturn($this->streamInterface);
+        $this->streamInterface->shouldReceive('__toString')
             ->twice()->andReturn($responseBody);
         $this->response->shouldReceive('getStatusCode')
             ->twice()->andReturn($this->responseStatus);
@@ -330,7 +340,7 @@ class LtiServiceConnectorTest extends TestCase
     private function mockRequestReturnsA401()
     {
         $mockError = Mockery::mock(ClientException::class);
-        $mockResponse = Mockery::mock(ResponseInterface::class);
+        $mockResponse = Mockery::mock(Response::class);
         $mockError->shouldReceive('getResponse')
             ->once()->andReturn($mockResponse);
         $mockResponse->shouldReceive('getStatusCode')


### PR DESCRIPTION
## Summary of Changes

<!-- A few sentences describing the big picture of your changes. -->

Rather than using `file_get_contents()` to fetch the keyset, use the HTTP client provided in the service provider.

## Testing

I created a branch on our platform which uses these changes and verified the E2E tests pass.

- [x] I have added automated tests for my changes
