### PR TITLE
Default cache storage no longer wiping all but the latest nonce and launch body

### DIFF
--- a/src/ImsStorage/ImsCache.php
+++ b/src/ImsStorage/ImsCache.php
@@ -12,41 +12,38 @@ class ImsCache implements ICache
     {
         $this->loadCache();
 
-        return $this->cache[$key];
+        return $this->cache[$key] ?? null;
     }
 
     public function cacheLaunchData($key, $jwtBody)
     {
+        $this->loadCache();
+
         $this->cache[$key] = $jwtBody;
         $this->saveCache();
-
-        return $this;
     }
 
     public function cacheNonce($nonce)
     {
+        $this->loadCache();
+
         $this->cache['nonce'][$nonce] = true;
         $this->saveCache();
-
-        return $this;
     }
 
     public function checkNonce($nonce)
     {
         $this->loadCache();
-        if (!isset($this->cache['nonce'][$nonce])) {
-            return false;
-        }
 
-        return true;
+        return isset($this->cache['nonce'][$nonce]);
     }
 
     public function cacheAccessToken($key, $accessToken)
     {
+        $this->loadCache();
+
         $this->cache[$key] = $accessToken;
         $this->saveCache();
-
-        return $this;
     }
 
     public function getAccessToken($key)
@@ -59,6 +56,7 @@ class ImsCache implements ICache
     public function clearAccessToken($key)
     {
         $this->loadCache();
+
         unset($this->cache[$key]);
         $this->saveCache();
 


### PR DESCRIPTION
## Summary of Changes

Because the cacheLaunchData() and cacheNonce() methods do not load the cache prior to setting it, it effectively wipes out the cache each load. I think this would likely cause problems for applications where more than one user could be accessing the application at once. I have implemented my own cache, but thought I would fix this for others and to make sure I am understanding it right. We don't want it to wipe the entire cache each load, right? I think the launch data may be useful for a future request as the key is passed around. Since the default storage is in a system temp file, it will get wiped eventually by the system.

Furthermore, is there a reason $this was being returned in the functions that set cache values? I looked through the code and it isn't chained anywhere, nor is the return value used as far as I could tell. I removed those return statements.

Also, 'Issues' aren't available on this project, so I wanted to use this pull request to ask a general question about the nonce. Is it enough to validate that the nonce exists in the cache, or does it need to be correlated to the launch key in some way, or pulled from a session/cookie? The nonce helps avoid replay attacks, but I am not familiar enough with OIDC to know if it is working properly here, since they aren't deleted from the cache on use or correlated with a specific request.

## Testing

Manual testing
