### PR TITLE
Clean up logic for putting a grade to a line item, add helper functions to extract default line item, and avoid extra line item lookups when not needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Implemented several changes to comply with (OpenID Connect Core)[https://openid.
 * Fix an issue with nonce validation not checking against the value in the Authentication Request.
 * Add stricter typing to `ICache` and `ICookie`.
 * Rename the `ICache::getNonce()` method to `ICache::checkNonceIsValid()`.
+* Improve how line items are fetched and created when putting a grade to a line item.
 
 ## 4.1.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Implemented several changes to comply with (OpenID Connect Core)[https://openid.
 * Fix an issue with nonce validation not checking against the value in the Authentication Request.
 * Add stricter typing to `ICache` and `ICookie`.
 * Rename the `ICache::getNonce()` method to `ICache::checkNonceIsValid()`.
-* Improve how line items are fetched and created when putting a grade to a line item.
+* Improve how line items are fetched and created when putting a grade to a line item. ([#44](https://github.com/packbackbooks/lti-1-3-php-library/pull/44))
 
 ## 4.1.3
 

--- a/UPGRADES.md
+++ b/UPGRADES.md
@@ -6,6 +6,7 @@ Version 4.0 introduced changes to the `Packback\Lti1p3\Interfaces\ICache` interf
 
 * The method `checkNonce()` was renamed to `checkNonceIsValid()`.
 * A second required argument (`$state`) was added to the `cacheNonce()` and `checkNonceIsValid()` methods.
+* Stricter typing was introduced for several methods: `getLaunchData`, `cacheLaunchData`, `cacheNonce`, `cacheAccessToken`, `getAccessToken`, and `clearAccessToken`.
 
 ### Stricter typing on `ICache` and `ICookie` methods
 

--- a/UPGRADES.md
+++ b/UPGRADES.md
@@ -2,11 +2,16 @@
 
 ### Changes to `ICache` methods
 
-Version 4.0 introduced changes to the `Packback\Lti1p3\Interfaces\ICache` interface.
+Version 5.0 introduced changes to the `Packback\Lti1p3\Interfaces\ICache` interface.
 
 * The method `checkNonce()` was renamed to `checkNonceIsValid()`.
 * A second required argument (`$state`) was added to the `cacheNonce()` and `checkNonceIsValid()` methods.
 * Stricter typing was introduced for several methods: `getLaunchData`, `cacheLaunchData`, `cacheNonce`, `cacheAccessToken`, `getAccessToken`, and `clearAccessToken`.
+
+Stricter typing was added to methods on several interfaces.
+
+* On `ICache` the following methods are now more strictly typed: `getLaunchData`, `cacheLaunchData`, `cacheNonce`, `cacheAccessToken`, `getAccessToken`, and `clearAccessToken`.
+* On `ICookie` the following methods are now more strictly typed: `getCookie`, and `setCookie`.
 
 ### Stricter typing on `ICache` and `ICookie` methods
 

--- a/src/LtiAssignmentsGradesService.php
+++ b/src/LtiAssignmentsGradesService.php
@@ -25,8 +25,7 @@ class LtiAssignmentsGradesService extends LtiAbstractService
             return null;
         }
 
-        $lineitem = LtiLineitem::new()->setId($serviceData['lineitem']);
-        return $lineitem;
+        return LtiLineitem::new()->setId($serviceData['lineitem']);
     }
 
     public function putGrade(LtiGrade $grade, LtiLineitem $lineitem = null)
@@ -94,7 +93,9 @@ class LtiAssignmentsGradesService extends LtiAbstractService
     public function findOrCreateLineitem(LtiLineitem $newLineItem): LtiLineitem
     {
         $lineitem = $this->findLineItem($newLineItem);
-        if ($lineitem !== null) { return $lineitem; }
+        if ($lineitem !== null) {
+            return $lineitem;
+        }
 
         return $this->createLineitem($newLineItem);
     }
@@ -107,8 +108,7 @@ class LtiAssignmentsGradesService extends LtiAbstractService
                 $lineitem = $this->findOrCreateLineitem($lineitem);
             }
             $resultsUrl = $lineitem->getId();
-        }
-        else {
+        } else {
             if (empty($this->getServiceData()['lineitem'])) {
                 throw new Exception('Missing Line item');
             }

--- a/src/LtiAssignmentsGradesService.php
+++ b/src/LtiAssignmentsGradesService.php
@@ -35,10 +35,8 @@ class LtiAssignmentsGradesService extends LtiAbstractService
         }
 
         // If the line item already contains the Id, we do not need to find or create it.
-        if ($lineitem !== null) {
-            if (empty($lineitem->getId())) {
-                $lineitem = $this->findOrCreateLineitem($lineitem);
-            }
+        if ($lineitem !== null && empty($lineitem->getId())) {
+            $lineitem = $this->findOrCreateLineitem($lineitem);
         }
 
         // Otherwise, if no line item is passed in, attempt to use the one associated with
@@ -92,12 +90,7 @@ class LtiAssignmentsGradesService extends LtiAbstractService
 
     public function findOrCreateLineitem(LtiLineitem $newLineItem): LtiLineitem
     {
-        $lineitem = $this->findLineItem($newLineItem);
-        if ($lineitem !== null) {
-            return $lineitem;
-        }
-
-        return $this->createLineitem($newLineItem);
+        return $this->findLineItem($newLineItem) ?? $this->createLineitem($newLineItem);
     }
 
     public function getGrades(LtiLineitem $lineitem = null)

--- a/src/LtiAssignmentsGradesService.php
+++ b/src/LtiAssignmentsGradesService.php
@@ -80,15 +80,8 @@ class LtiAssignmentsGradesService extends LtiAbstractService
 
     public function getGrades(LtiLineitem $lineitem = null)
     {
-        if (isset($lineitem)) {
-            $lineitem = $this->ensureLineItemExists($lineitem);
-            $resultsUrl = $lineitem->getId();
-        } else {
-            if (empty($this->getServiceData()['lineitem'])) {
-                throw new Exception('Missing Line item');
-            }
-            $resultsUrl = $this->getServiceData()['lineitem'];
-        }
+        $lineitem = $this->ensureLineItemExists($lineitem);
+        $resultsUrl = $lineitem->getId();
 
         // Place '/results' before url params
         $pos = strpos($resultsUrl, '?');

--- a/src/LtiAssignmentsGradesService.php
+++ b/src/LtiAssignmentsGradesService.php
@@ -49,30 +49,6 @@ class LtiAssignmentsGradesService extends LtiAbstractService
         return $this->makeServiceRequest($request);
     }
 
-    public function ensureLineItemExists(LtiLineitem $lineitem = null): LtiLineitem
-    {
-        // If no line item is passed in, attempt to use the one associated with
-        // this launch.
-        if (!isset($lineitem)) {
-            $lineitem = $this->getResourceLaunchLineItem();
-        }
-
-        // If none exists still, create a default line item.
-        if (!isset($lineitem)) {
-            $defaultLineitem = LtiLineitem::new()
-                ->setLabel('default')
-                ->setScoreMaximum(100);
-            $lineitem = $this->createLineitem($defaultLineitem);
-        }
-
-        // If the line item does not contain an ID, find or create it.
-        if (empty($lineitem->getId())) {
-            $lineitem = $this->findOrCreateLineitem($lineitem);
-        }
-
-        return $lineitem;
-    }
-
     public function findLineItem(LtiLineitem $newLineItem): ?LtiLineitem
     {
         $lineitems = $this->getLineItems();
@@ -104,11 +80,8 @@ class LtiAssignmentsGradesService extends LtiAbstractService
 
     public function getGrades(LtiLineitem $lineitem = null)
     {
-        if ($lineitem !== null) {
-            // Skip line item lookup/creation if we already know the Id
-            if (empty($lineitem->getId())) {
-                $lineitem = $this->findOrCreateLineitem($lineitem);
-            }
+        if (isset($lineitem)) {
+            $lineitem = $this->ensureLineItemExists($lineitem);
             $resultsUrl = $lineitem->getId();
         } else {
             if (empty($this->getServiceData()['lineitem'])) {
@@ -148,6 +121,30 @@ class LtiAssignmentsGradesService extends LtiAbstractService
         }
 
         return $lineitems;
+    }
+
+    private function ensureLineItemExists(LtiLineitem $lineitem = null): LtiLineitem
+    {
+        // If no line item is passed in, attempt to use the one associated with
+        // this launch.
+        if (!isset($lineitem)) {
+            $lineitem = $this->getResourceLaunchLineItem();
+        }
+
+        // If none exists still, create a default line item.
+        if (!isset($lineitem)) {
+            $defaultLineitem = LtiLineitem::new()
+                ->setLabel('default')
+                ->setScoreMaximum(100);
+            $lineitem = $this->createLineitem($defaultLineitem);
+        }
+
+        // If the line item does not contain an ID, find or create it.
+        if (empty($lineitem->getId())) {
+            $lineitem = $this->findOrCreateLineitem($lineitem);
+        }
+
+        return $lineitem;
     }
 
     private function isMatchingLineitem(array $lineitem, LtiLineitem $newLineItem): bool


### PR DESCRIPTION
## Summary of Changes

<!-- A few sentences describing the big picture of your changes. -->

This PR makes a few changes from the original PR (https://github.com/packbackbooks/lti-1-3-php-library/pull/42). These changes are primarily linting and the recommendations. Refer to the other PR for a more detailed discussion of why these changes have been made. (I created a separate branch myself so I could easily make changes and test it locally).

## Testing

<!-- Describe how this PR has been tested, manually and automatically. -->

- [x] I have added automated tests for my changes
- [x] Test it on our API to ensure it works
