### PR TITLE
Fix a PHP warning when optional 'data' property of deep link settings is not present in message launch.

### DIFF
--- a/src/LtiDeepLink.php
+++ b/src/LtiDeepLink.php
@@ -30,8 +30,13 @@ class LtiDeepLink
             LtiConstants::MESSAGE_TYPE => 'LtiDeepLinkingResponse',
             LtiConstants::VERSION => LtiConstants::V1_3,
             LtiConstants::DL_CONTENT_ITEMS => array_map(function ($resource) { return $resource->toArray(); }, $resources),
-            LtiConstants::DL_DATA => $this->deep_link_settings['data'],
         ];
+
+        # https://www.imsglobal.org/spec/lti-dl/v2p0/#deep-linking-request-message
+        # 'data' is an optional property which, if it exists, must be returned by the tool
+        if (isset($this->deep_link_settings['data'])) {
+            $message_jwt[LtiConstants::DL_DATA] = $this->deep_link_settings['data'];
+        }
 
         return JWT::encode($message_jwt, $this->registration->getToolPrivateKey(), 'RS256', $this->registration->getKid());
     }

--- a/src/LtiDeepLink.php
+++ b/src/LtiDeepLink.php
@@ -32,8 +32,8 @@ class LtiDeepLink
             LtiConstants::DL_CONTENT_ITEMS => array_map(function ($resource) { return $resource->toArray(); }, $resources),
         ];
 
-        # https://www.imsglobal.org/spec/lti-dl/v2p0/#deep-linking-request-message
-        # 'data' is an optional property which, if it exists, must be returned by the tool
+        // https://www.imsglobal.org/spec/lti-dl/v2p0/#deep-linking-request-message
+        // 'data' is an optional property which, if it exists, must be returned by the tool
         if (isset($this->deep_link_settings['data'])) {
             $message_jwt[LtiConstants::DL_DATA] = $this->deep_link_settings['data'];
         }


### PR DESCRIPTION
## Summary of Changes

Resolves a PHP warning that was noted in issue https://github.com/packbackbooks/lti-1-3-php-library/issues/43

Per specs at https://www.imsglobal.org/spec/lti-dl/v2p0/#deep-linking-settings the 'data' property of deep link settings is optional. In the scenario where this field was not sent by the platform (tested on Canvas) a PHP warning would be thrown:

`PHP message: PHP Notice: Undefined index: data in /.../vendor/packbackbooks/lti-1p3-tool/src/LtiDeepLink.php on line 33`

This change ensures that the 'data' property in the deep link response is only returned if it was sent by the platform.

## Testing

Tested manually on Canvas