### PR TITLE
SEC-64 Add Apache license to composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "packbackbooks/lti-1p3-tool",
     "type": "library",
     "description": "A library used for building IMS-certified LTI 1.3 tool providers in PHP.",
+    "license": "Apache-2.0",
     "keywords": [
         "lti"
     ],


### PR DESCRIPTION
Added the `"license": "Apache-2.0",` line to the `composer.json` file so it will no longer be flagged for not having a license by our linter.

@dbhynds