### PR TITLE
MGMT-61 Fix key alg

### DIFF
--- a/src/LtiMessageLaunch.php
+++ b/src/LtiMessageLaunch.php
@@ -38,6 +38,8 @@ class LtiMessageLaunch
     public const ERR_VALIDATOR_CONFLICT = 'Validator conflict.';
     public const ERR_UNRECOGNIZED_MESSAGE_TYPE = 'Unrecognized message type.';
     public const ERR_INVALID_MESSAGE = 'Message validation failed.';
+    public const ERR_INVALID_ALG = 'Invalid alg was specified in the JWT header.';
+    public const ERR_MISMATCHED_ALG_KEY = 'The alg specified in the JWT header is incompatible with the JWK key type.';
 
     private $db;
     private $cache;
@@ -47,6 +49,16 @@ class LtiMessageLaunch
     private $jwt;
     private $registration;
     private $launch_id;
+
+    // See https://www.imsglobal.org/spec/security/v1p1#approved-jwt-signing-algorithms.
+    private static $ltiSupportedAlgs = [
+        'RS256' => 'RSA',
+        'RS384' => 'RSA',
+        'RS512' => 'RSA',
+        'ES256' => 'EC',
+        'ES384' => 'EC',
+        'ES512' => 'EC',
+    ];
 
     /**
      * Constructor.
@@ -285,6 +297,10 @@ class LtiMessageLaunch
         // Find key used to sign the JWT (matches the KID in the header)
         foreach ($publicKeySet['keys'] as $key) {
             if ($key['kid'] == $this->jwt['header']['kid']) {
+                // If alg is omitted from the JWK, infer it from the JWT header alg.
+                // See https://datatracker.ietf.org/doc/html/rfc7517#section-4.4.
+                $key['alg'] = $this->inferKeyAlgorithm($key);
+
                 try {
                     $keySet = JWK::parseKeySet([
                         'keys' => [$key],
@@ -301,6 +317,28 @@ class LtiMessageLaunch
 
         // Could not find public key with a matching kid and alg.
         throw new LtiException(static::ERR_NO_PUBLIC_KEY);
+    }
+
+    private function inferKeyAlgorithm(array $key): string
+    {
+        if (isset($key['alg'])) {
+            return $key['alg'];
+        }
+
+        // The header alg must match the key type (family) specified in the JWK's kty.
+        if ($this->jwtAlgMatchesJwkKty($key)) {
+            return $this->jwt['header']['alg'];
+        }
+
+        throw new LtiException(static::ERR_MISMATCHED_ALG_KEY);
+    }
+
+    private function jwtAlgMatchesJwkKty($key): bool
+    {
+        $jwtAlg = $this->jwt['header']['alg'];
+
+        return isset(static::$ltiSupportedAlgs[$jwtAlg]) &&
+            static::$ltiSupportedAlgs[$jwtAlg] == $key['kty'];
     }
 
     private function cacheLaunchData()

--- a/src/LtiMessageLaunch.php
+++ b/src/LtiMessageLaunch.php
@@ -297,9 +297,7 @@ class LtiMessageLaunch
         // Find key used to sign the JWT (matches the KID in the header)
         foreach ($publicKeySet['keys'] as $key) {
             if ($key['kid'] == $this->jwt['header']['kid']) {
-                // If alg is omitted from the JWK, infer it from the JWT header alg.
-                // See https://datatracker.ietf.org/doc/html/rfc7517#section-4.4.
-                $key['alg'] = $this->inferKeyAlgorithm($key);
+                $key['alg'] = $this->getKeyAlgorithm($key);
 
                 try {
                     $keySet = JWK::parseKeySet([
@@ -319,8 +317,12 @@ class LtiMessageLaunch
         throw new LtiException(static::ERR_NO_PUBLIC_KEY);
     }
 
-    private function inferKeyAlgorithm(array $key): string
-    {
+    /**
+     * If alg is omitted from the JWK, infer it from the JWT header alg.
+     * See https://datatracker.ietf.org/doc/html/rfc7517#section-4.4.
+     */
+    private function getKeyAlgorithm(array $key): string
+    { 
         if (isset($key['alg'])) {
             return $key['alg'];
         }
@@ -338,7 +340,7 @@ class LtiMessageLaunch
         $jwtAlg = $this->jwt['header']['alg'];
 
         return isset(static::$ltiSupportedAlgs[$jwtAlg]) &&
-            static::$ltiSupportedAlgs[$jwtAlg] == $key['kty'];
+            static::$ltiSupportedAlgs[$jwtAlg] === $key['kty'];
     }
 
     private function cacheLaunchData()

--- a/src/LtiMessageLaunch.php
+++ b/src/LtiMessageLaunch.php
@@ -322,7 +322,7 @@ class LtiMessageLaunch
      * See https://datatracker.ietf.org/doc/html/rfc7517#section-4.4.
      */
     private function getKeyAlgorithm(array $key): string
-    { 
+    {
         if (isset($key['alg'])) {
             return $key['alg'];
         }


### PR DESCRIPTION
## Summary of Changes

Ensures that an JWK alg is set. Technically this property is optional and D2L doesn't include it currently. If someone's app is using `"firebase/php-jwt": "^6.0"` in their `composer.lock`, D2L launches would fail. (For the PR reviewer, currently we're using `^5.2` in our app, which is why the recent change didn't break D2L launches. It only affects `^6.0`.)

See this conversation for more details: https://github.com/packbackbooks/lti-1-3-php-library/issues/50. Thanks to snake for raising this issue.

## Testing

<!-- Describe how this PR has been tested, manually and automatically. -->

- [ ] I have added automated tests for my changes

^^^ No, but I manually tested it. Here's a pipeline where LTI tests pass using 6.0: https://gitlab.com/packback/questions/-/pipelines/517060983. There are some other failing tests, because I had to remove the google classroom library (which requires 5.2) to get our app to use 6.0. This is mostly just to prove that LTI 1.3 launches still work with this change. (I obviously won't leave google classroom commented out in the final PR).