### PR TITLE
PODB-520 Improve logging on the LtiServiceConnector

### DIFF
--- a/src/LtiServiceConnector.php
+++ b/src/LtiServiceConnector.php
@@ -42,6 +42,7 @@ class LtiServiceConnector implements ILtiServiceConnector
             static::SYNC_GRADE_REQUEST => 'Syncing grade for this lti_user_id: ',
             static::CREATE_LINEITEM_REQUEST => 'Creating lineitem: ',
             static::GET_LINEITEMS_REQUEST => 'Getting lineitems: ',
+            static::AUTH_REQUEST => 'Authenticating: ',
         ];
     }
 

--- a/src/LtiServiceConnector.php
+++ b/src/LtiServiceConnector.php
@@ -23,6 +23,7 @@ class LtiServiceConnector implements ILtiServiceConnector
     public const SYNC_GRADE_REQUEST = 1;
     public const CREATE_LINEITEM_REQUEST = 2;
     public const GET_LINEITEMS_REQUEST = 3;
+    public const AUTH_REQUEST = 3;
 
     private $cache;
     private $client;
@@ -106,7 +107,7 @@ class LtiServiceConnector implements ILtiServiceConnector
 
         if ($this->debuggingMode) {
             $this->logRequest(
-                $request->getMethod(),
+                static::AUTH_REQUEST,
                 $request,
                 $this->getResponseHeaders($response),
                 $this->getResponseBody($response)

--- a/tests/LtiServiceConnectorTest.php
+++ b/tests/LtiServiceConnectorTest.php
@@ -96,7 +96,7 @@ class LtiServiceConnectorTest extends TestCase
 
         $this->cache->shouldReceive('getAccessToken')
             ->once()->andReturn(false);
-        $this->client->shouldReceive('post')
+        $this->client->shouldReceive('request')
             ->once()->andReturn($this->response);
         $this->response->shouldReceive('getBody')
             ->once()->andReturn($this->streamInterface);


### PR DESCRIPTION
## Summary of Changes

Previously, when debugging mode was enabled, we only logged service requests. When it came to getting an access token, we called `$this->client->post()` which meant the request was never logged.

This implements a change such that all requests get funneled through `makeRequest()` which also handles logging the responses of those requests. This should enable debug logging if auth requests fail.

## Testing

<!-- Describe how this PR has been tested, manually and automatically. -->

- [ ] I have added automated tests for my changes

Still need to manually test.
