### PR TITLE
ONCALL-391 Fix LTI Header

### DIFF
--- a/src/LtiServiceConnector.php
+++ b/src/LtiServiceConnector.php
@@ -87,7 +87,9 @@ class LtiServiceConnector implements ILtiServiceConnector
 
         // Get Access
         $request = new ServiceRequest(static::METHOD_POST, $url);
-        $request->setBody(json_encode($authRequest));
+        $request->setBody(json_encode([
+            'form-params' => $authRequest,
+        ]));
         $response = $this->makeRequest($request);
 
         $tokenData = $this->getResponseBody($response);

--- a/src/LtiServiceConnector.php
+++ b/src/LtiServiceConnector.php
@@ -87,9 +87,7 @@ class LtiServiceConnector implements ILtiServiceConnector
 
         // Get Access
         $request = new ServiceRequest(static::METHOD_POST, $url);
-        $request->setBody(json_encode([
-            'form-params' => $authRequest,
-        ]));
+        $request->setPayload(['form_params' => $authRequest]);
         $response = $this->makeRequest($request);
 
         $tokenData = $this->getResponseBody($response);

--- a/src/ServiceRequest.php
+++ b/src/ServiceRequest.php
@@ -9,6 +9,7 @@ class ServiceRequest implements IServiceRequest
     private $method;
     private $url;
     private $body;
+    private $payload;
     private $accessToken;
     private $contentType = 'application/json';
     private $accept = 'application/json';
@@ -31,6 +32,10 @@ class ServiceRequest implements IServiceRequest
 
     public function getPayload(): array
     {
+        if (isset($this->payload)) {
+            return $this->payload;
+        }
+
         $payload = [
             'headers' => $this->getHeaders(),
         ];
@@ -60,6 +65,13 @@ class ServiceRequest implements IServiceRequest
     public function setBody(string $body): IServiceRequest
     {
         $this->body = $body;
+
+        return $this;
+    }
+
+    public function setPayload(array $payload): IServiceRequest
+    {
+        $this->payload = $payload;
 
         return $this;
     }


### PR DESCRIPTION
## Summary of Changes

In order to pass LMSes the same data we did previously we have changed the way we are forming the payload for our auth requests. This should fix the issues we are seeing with launching D2L and Blackboard instances. 

## Testing

We have manually verified that the headers on the request now match what they previously were, and have tested the changes in the development environment.
