### PR TITLE
PODB-563: Add functions for updating line items

### DIFF
--- a/src/Enums/RequestTypes.php
+++ b/src/Enums/RequestTypes.php
@@ -17,12 +17,12 @@ enum RequestTypes
     public function error(): string
     {
         return match ($this) {
-            RequestType::UNSUPPORTED_REQUEST => 'Logging request data: ',
-            RequestType::SYNC_GRADE_REQUEST => 'Syncing grade for this lti_user_id: ',
-            RequestType::CREATE_LINEITEM_REQUEST => 'Creating lineitem: ',
-            RequestType::GET_LINEITEMS_REQUEST => 'Getting lineitems: ',
-            RequestType::UPDATE_LINEITEM_REQUEST => 'Updating lineitem: ',
-            RequestType::AUTH_REQUEST => 'Authenticating: ',
+            RequestTypes::UNSUPPORTED_REQUEST => 'Logging request data: ',
+            RequestTypes::SYNC_GRADE_REQUEST => 'Syncing grade for this lti_user_id: ',
+            RequestTypes::CREATE_LINEITEM_REQUEST => 'Creating lineitem: ',
+            RequestTypes::GET_LINEITEMS_REQUEST => 'Getting lineitems: ',
+            RequestTypes::UPDATE_LINEITEM_REQUEST => 'Updating lineitem: ',
+            RequestTypes::AUTH_REQUEST => 'Authenticating: ',
         };
     }
 }

--- a/src/Enums/RequestTypes.php
+++ b/src/Enums/RequestTypes.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Packback\Lti1p3\Enums;
+
+/**
+ * Supported request types which map to an error log message.
+ */
+enum RequestTypes
+{
+    case UNSUPPORTED_REQUEST;
+    case SYNC_GRADE_REQUEST;
+    case CREATE_LINEITEM_REQUEST;
+    case GET_LINEITEMS_REQUEST;
+    case UPDATE_LINEITEM_REQUEST;
+    case AUTH_REQUEST;
+
+    public function error(): string
+    {
+        return match ($this) {
+            RequestType::UNSUPPORTED_REQUEST => 'Logging request data: ',
+            RequestType::SYNC_GRADE_REQUEST => 'Syncing grade for this lti_user_id: ',
+            RequestType::CREATE_LINEITEM_REQUEST => 'Creating lineitem: ',
+            RequestType::GET_LINEITEMS_REQUEST => 'Getting lineitems: ',
+            RequestType::UPDATE_LINEITEM_REQUEST => 'Updating lineitem: ',
+            RequestType::AUTH_REQUEST => 'Authenticating: ',
+        };
+    }
+}

--- a/src/Interfaces/ILtiServiceConnector.php
+++ b/src/Interfaces/ILtiServiceConnector.php
@@ -16,7 +16,6 @@ interface ILtiServiceConnector
         ILtiRegistration $registration,
         array $scopes,
         IServiceRequest $request,
-        ?int $requestType = null,
         bool $shouldRetry = true
     ): array;
 
@@ -24,8 +23,7 @@ interface ILtiServiceConnector
         ILtiRegistration $registration,
         array $scopes,
         IServiceRequest $request,
-        string $key,
-        ?int $requestType = null
+        string $key
     ): array;
 
     public function setDebuggingMode(bool $enable): void;

--- a/src/LtiAbstractService.php
+++ b/src/LtiAbstractService.php
@@ -36,24 +36,22 @@ abstract class LtiAbstractService
 
     abstract public function getScope(): array;
 
-    protected function makeServiceRequest(IServiceRequest $request, ?int $requestType = null): array
+    protected function makeServiceRequest(IServiceRequest $request): array
     {
         return $this->serviceConnector->makeServiceRequest(
             $this->registration,
             $this->getScope(),
-            $request,
-            $requestType
+            $request
         );
     }
 
-    protected function getAll(IServiceRequest $request, string $key = null, ?int $requestType = null): array
+    protected function getAll(IServiceRequest $request, string $key = null): array
     {
         return $this->serviceConnector->getAll(
             $this->registration,
             $this->getScope(),
             $request,
-            $key,
-            $requestType
+            $key
         );
     }
 }

--- a/src/LtiAssignmentsGradesService.php
+++ b/src/LtiAssignmentsGradesService.php
@@ -66,9 +66,8 @@ class LtiAssignmentsGradesService extends LtiAbstractService
     {
         $request = new ServiceRequest(LtiServiceConnector::METHOD_PUT, $this->getServiceData()['lineitems']);
 
-        // Note: Content type is left as `application/json` since Blackboard
-        // throws 415 errors with content type `static::CONTENTTYPE_LINEITEM`
         $request->setBody($lineitemToUpdate)
+            ->setContentType(static::CONTENTTYPE_LINEITEM)
             ->setAccept(static::CONTENTTYPE_LINEITEM);
 
         $updatedLineitem = $this->makeServiceRequest($request, LtiServiceConnector::UPDATE_LINEITEM_REQUEST);

--- a/src/LtiAssignmentsGradesService.php
+++ b/src/LtiAssignmentsGradesService.php
@@ -62,6 +62,17 @@ class LtiAssignmentsGradesService extends LtiAbstractService
         return null;
     }
 
+    public function updateLineItem(LtiLineItem $updatedLineitem): LtiLineitem
+    {
+        $request = new ServiceRequest(LtiServiceConnector::METHOD_PUT, $this->getServiceData()['lineitems']);
+        $request->setBody($updatedLineitem)
+            ->setContentType(static::CONTENTTYPE_LINEITEM)
+            ->setAccept(static::CONTENTTYPE_LINEITEM);
+        $updatedLineitem = $this->makeServiceRequest($request, LtiServiceConnector::UPDATE_LINEITEM_REQUEST);
+
+        return new LtiLineitem($updatedLineitem['body']);
+    }
+
     public function createLineitem(LtiLineitem $newLineItem): LtiLineitem
     {
         $request = new ServiceRequest(LtiServiceConnector::METHOD_POST, $this->getServiceData()['lineitems']);

--- a/src/LtiAssignmentsGradesService.php
+++ b/src/LtiAssignmentsGradesService.php
@@ -2,6 +2,8 @@
 
 namespace Packback\Lti1p3;
 
+use Packback\Lti1p3\Enums\RequestTypes;
+
 class LtiAssignmentsGradesService extends LtiAbstractService
 {
     public const CONTENTTYPE_SCORE = 'application/vnd.ims.lis.v1.score+json';
@@ -42,11 +44,11 @@ class LtiAssignmentsGradesService extends LtiAbstractService
         $pos = strpos($scoreUrl, '?');
         $scoreUrl = $pos === false ? $scoreUrl.'/scores' : substr_replace($scoreUrl, '/scores', $pos, 0);
 
-        $request = new ServiceRequest(LtiServiceConnector::METHOD_POST, $scoreUrl);
+        $request = new ServiceRequest(LtiServiceConnector::METHOD_POST, $scoreUrl, RequestTypes::SYNC_GRADE_REQUEST);
         $request->setBody($grade);
         $request->setContentType(static::CONTENTTYPE_SCORE);
 
-        return $this->makeServiceRequest($request, LtiServiceConnector::SYNC_GRADE_REQUEST);
+        return $this->makeServiceRequest($request);
     }
 
     public function findLineItem(LtiLineitem $newLineItem): ?LtiLineitem
@@ -64,24 +66,24 @@ class LtiAssignmentsGradesService extends LtiAbstractService
 
     public function updateLineitem(LtiLineItem $lineitemToUpdate): LtiLineitem
     {
-        $request = new ServiceRequest(LtiServiceConnector::METHOD_PUT, $this->getServiceData()['lineitems']);
+        $request = new ServiceRequest(LtiServiceConnector::METHOD_PUT, $this->getServiceData()['lineitems'], RequestTypes::UPDATE_LINEITEM_REQUEST);
 
         $request->setBody($lineitemToUpdate)
             ->setContentType(static::CONTENTTYPE_LINEITEM)
             ->setAccept(static::CONTENTTYPE_LINEITEM);
 
-        $updatedLineitem = $this->makeServiceRequest($request, LtiServiceConnector::UPDATE_LINEITEM_REQUEST);
+        $updatedLineitem = $this->makeServiceRequest($request);
 
         return new LtiLineitem($updatedLineitem['body']);
     }
 
     public function createLineitem(LtiLineitem $newLineItem): LtiLineitem
     {
-        $request = new ServiceRequest(LtiServiceConnector::METHOD_POST, $this->getServiceData()['lineitems']);
+        $request = new ServiceRequest(LtiServiceConnector::METHOD_POST, $this->getServiceData()['lineitems'], RequestTypes::CREATE_LINEITEM_REQUEST);
         $request->setBody($newLineItem)
             ->setContentType(static::CONTENTTYPE_LINEITEM)
             ->setAccept(static::CONTENTTYPE_LINEITEM);
-        $createdLineItem = $this->makeServiceRequest($request, LtiServiceConnector::CREATE_LINEITEM_REQUEST);
+        $createdLineItem = $this->makeServiceRequest($request, LtiServiceConnector);
 
         return new LtiLineitem($createdLineItem['body']);
     }
@@ -115,11 +117,12 @@ class LtiAssignmentsGradesService extends LtiAbstractService
 
         $request = new ServiceRequest(
             LtiServiceConnector::METHOD_GET,
-            $this->getServiceData()['lineitems']
+            $this->getServiceData()['lineitems'],
+            RequestTypes::GET_LINEITEMS_REQUEST
         );
         $request->setAccept(static::CONTENTTYPE_LINEITEMCONTAINER);
 
-        $lineitems = $this->getAll($request, null, LtiServiceConnector::GET_LINEITEMS_REQUEST);
+        $lineitems = $this->getAll($request, null);
 
         // If there is only one item, then wrap it in an array so the foreach works
         if (isset($lineitems['body']['id'])) {

--- a/src/LtiAssignmentsGradesService.php
+++ b/src/LtiAssignmentsGradesService.php
@@ -62,12 +62,15 @@ class LtiAssignmentsGradesService extends LtiAbstractService
         return null;
     }
 
-    public function updateLineItem(LtiLineItem $updatedLineitem): LtiLineitem
+    public function updateLineitem(LtiLineItem $lineitemToUpdate): LtiLineitem
     {
         $request = new ServiceRequest(LtiServiceConnector::METHOD_PUT, $this->getServiceData()['lineitems']);
-        $request->setBody($updatedLineitem)
-            ->setContentType(static::CONTENTTYPE_LINEITEM)
+
+        // Note: Content type is left as `application/json` since Blackboard
+        // throws 415 errors with content type `static::CONTENTTYPE_LINEITEM`
+        $request->setBody($lineitemToUpdate)
             ->setAccept(static::CONTENTTYPE_LINEITEM);
+
         $updatedLineitem = $this->makeServiceRequest($request, LtiServiceConnector::UPDATE_LINEITEM_REQUEST);
 
         return new LtiLineitem($updatedLineitem['body']);

--- a/src/LtiAssignmentsGradesService.php
+++ b/src/LtiAssignmentsGradesService.php
@@ -83,7 +83,7 @@ class LtiAssignmentsGradesService extends LtiAbstractService
         $request->setBody($newLineItem)
             ->setContentType(static::CONTENTTYPE_LINEITEM)
             ->setAccept(static::CONTENTTYPE_LINEITEM);
-        $createdLineItem = $this->makeServiceRequest($request, LtiServiceConnector);
+        $createdLineItem = $this->makeServiceRequest($request);
 
         return new LtiLineitem($createdLineItem['body']);
     }

--- a/src/LtiMessageLaunch.php
+++ b/src/LtiMessageLaunch.php
@@ -91,7 +91,7 @@ class LtiMessageLaunch
         ICache $cache = null,
         ICookie $cookie = null,
         ILtiServiceConnector $serviceConnector = null
-        ) {
+    ) {
         return new LtiMessageLaunch($database, $cache, $cookie, $serviceConnector);
     }
 

--- a/src/LtiServiceConnector.php
+++ b/src/LtiServiceConnector.php
@@ -17,13 +17,15 @@ class LtiServiceConnector implements ILtiServiceConnector
 
     public const METHOD_GET = 'GET';
     public const METHOD_POST = 'POST';
+    public const METHOD_PUT = 'PUT';
 
     // Supported request types which map to an error log message
     public const UNSUPPORTED_REQUEST = 0;
     public const SYNC_GRADE_REQUEST = 1;
     public const CREATE_LINEITEM_REQUEST = 2;
     public const GET_LINEITEMS_REQUEST = 3;
-    public const AUTH_REQUEST = 3;
+    public const UPDATE_LINEITEM_REQUEST = 4;
+    public const AUTH_REQUEST = 5;
 
     private $cache;
     private $client;
@@ -42,6 +44,7 @@ class LtiServiceConnector implements ILtiServiceConnector
             static::SYNC_GRADE_REQUEST => 'Syncing grade for this lti_user_id: ',
             static::CREATE_LINEITEM_REQUEST => 'Creating lineitem: ',
             static::GET_LINEITEMS_REQUEST => 'Getting lineitems: ',
+            static::UPDATE_LINEITEM_REQUEST => 'Updating lineitem: ',
             static::AUTH_REQUEST => 'Authenticating: ',
         ];
     }

--- a/src/LtiServiceConnector.php
+++ b/src/LtiServiceConnector.php
@@ -19,18 +19,9 @@ class LtiServiceConnector implements ILtiServiceConnector
     public const METHOD_POST = 'POST';
     public const METHOD_PUT = 'PUT';
 
-    // Supported request types which map to an error log message
-    public const UNSUPPORTED_REQUEST = 0;
-    public const SYNC_GRADE_REQUEST = 1;
-    public const CREATE_LINEITEM_REQUEST = 2;
-    public const GET_LINEITEMS_REQUEST = 3;
-    public const UPDATE_LINEITEM_REQUEST = 4;
-    public const AUTH_REQUEST = 5;
-
     private $cache;
     private $client;
     private $debuggingMode = false;
-    private $errorMessages;
 
     public function __construct(
         ICache $cache,
@@ -38,15 +29,6 @@ class LtiServiceConnector implements ILtiServiceConnector
     ) {
         $this->cache = $cache;
         $this->client = $client;
-
-        $this->errorMessages = [
-            static::UNSUPPORTED_REQUEST => 'Logging request data: ',
-            static::SYNC_GRADE_REQUEST => 'Syncing grade for this lti_user_id: ',
-            static::CREATE_LINEITEM_REQUEST => 'Creating lineitem: ',
-            static::GET_LINEITEMS_REQUEST => 'Getting lineitems: ',
-            static::UPDATE_LINEITEM_REQUEST => 'Updating lineitem: ',
-            static::AUTH_REQUEST => 'Authenticating: ',
-        ];
     }
 
     public function setDebuggingMode(bool $enable): void
@@ -111,7 +93,6 @@ class LtiServiceConnector implements ILtiServiceConnector
 
         if ($this->debuggingMode) {
             $this->logRequest(
-                static::AUTH_REQUEST,
                 $request,
                 $this->getResponseHeaders($response),
                 $this->getResponseBody($response)
@@ -142,15 +123,8 @@ class LtiServiceConnector implements ILtiServiceConnector
         ILtiRegistration $registration,
         array $scopes,
         IServiceRequest $request,
-        ?int $requestType = null,
         bool $shouldRetry = true
     ): array {
-        // Set $requestType here, since static properties cannot be evaluated
-        // as parameters
-        if (!isset($requestType)) {
-            $requestType = self::UNSUPPORTED_REQUEST;
-        }
-
         $request->setAccessToken($this->getAccessToken($registration, $scopes));
 
         try {
@@ -164,7 +138,7 @@ class LtiServiceConnector implements ILtiServiceConnector
                 $key = $this->getAccessTokenCacheKey($registration, $scopes);
                 $this->cache->clearAccessToken($key);
 
-                return $this->makeServiceRequest($registration, $scopes, $request, $requestType, false);
+                return $this->makeServiceRequest($registration, $scopes, $request, false);
             }
 
             throw $e;
@@ -181,8 +155,7 @@ class LtiServiceConnector implements ILtiServiceConnector
         ILtiRegistration $registration,
         array $scopes,
         IServiceRequest $request,
-        string $key = null,
-        ?int $requestType = null
+        string $key = null
     ): array {
         if ($request->getMethod() !== static::METHOD_GET) {
             throw new \Exception('An invalid method was specified by an LTI service requesting all items.');
@@ -192,7 +165,7 @@ class LtiServiceConnector implements ILtiServiceConnector
         $nextUrl = $request->getUrl();
 
         while ($nextUrl) {
-            $response = $this->makeServiceRequest($registration, $scopes, $request, $requestType);
+            $response = $this->makeServiceRequest($registration, $scopes, $request);
 
             $page_results = $key === null ? ($response['body'] ?? []) : ($response['body'][$key] ?? []);
             $results = array_merge($results, $page_results);
@@ -207,7 +180,6 @@ class LtiServiceConnector implements ILtiServiceConnector
     }
 
     private function logRequest(
-        int $requestType,
         IServiceRequest $request,
         array $responseHeaders,
         ?array $responseBody
@@ -227,7 +199,7 @@ class LtiServiceConnector implements ILtiServiceConnector
 
         $userId = json_decode($requestBody)->userId ?? '';
 
-        $logMsg = $this->errorMessages[$requestType];
+        $logMsg = $request->getRequestType()->error();
 
         error_log($logMsg.$userId.' '.print_r($contextArray, true));
     }

--- a/src/ServiceRequest.php
+++ b/src/ServiceRequest.php
@@ -100,7 +100,8 @@ class ServiceRequest implements IServiceRequest
             $headers['Authorization'] = $this->accessToken;
         }
 
-        if ($this->getMethod() === LtiServiceConnector::METHOD_POST) {
+        // Include Content-Type for POST and PUT requests
+        if (in_array($this->getMethod(), [LtiServiceConnector::METHOD_POST, LtiServiceConnector::METHOD_PUT])) {
             $headers['Content-Type'] = $this->contentType;
         }
 

--- a/src/ServiceRequest.php
+++ b/src/ServiceRequest.php
@@ -2,6 +2,7 @@
 
 namespace Packback\Lti1p3;
 
+use Packback\Lti1p3\Enums\RequestTypes;
 use Packback\Lti1p3\Interfaces\IServiceRequest;
 
 class ServiceRequest implements IServiceRequest
@@ -13,11 +14,17 @@ class ServiceRequest implements IServiceRequest
     private $accessToken;
     private $contentType = 'application/json';
     private $accept = 'application/json';
+    private RequestTypes $requestType;
 
-    public function __construct(string $method, string $url)
+    public function __construct(string $method, string $url, ?RequestTypes $requestType = null)
     {
+        if (!isset($requestType)) {
+            $requestType = RequestTypes::UNSUPPORTED_REQUEST;
+        }
+
         $this->method = $method;
         $this->url = $url;
+        $this->requestType = $requestType;
     }
 
     public function getMethod(): string
@@ -46,6 +53,11 @@ class ServiceRequest implements IServiceRequest
         }
 
         return $payload;
+    }
+
+    public function getRequestType(): RequestTypes
+    {
+        return $this->requestType;
     }
 
     public function setUrl(string $url): IServiceRequest

--- a/tests/Certification/Lti13CertificationTest.php
+++ b/tests/Certification/Lti13CertificationTest.php
@@ -382,7 +382,7 @@ class Lti13CertificationTest extends TestCase
             }
 
             // I couldn't find a better output function
-            echo PHP_EOL."--> TESTING INVALID TEST CASE: ${testCase}";
+            echo PHP_EOL."--> TESTING INVALID TEST CASE: {$testCase}";
 
             $jwt = $this->buildJWT($payload, $this->issuer, $jwtHeader);
             if (isset($payload['nonce'])) {
@@ -434,7 +434,7 @@ class Lti13CertificationTest extends TestCase
             $payload['sub'] = 'lms-user-id';
 
             // I couldn't find a better output function
-            echo PHP_EOL."--> TESTING VALID TEST CASE: ${testCase}";
+            echo PHP_EOL."--> TESTING VALID TEST CASE: {$testCase}";
 
             $jwt = $this->buildJWT($payload, $this->issuer);
             $this->cache->cacheNonce($payload['nonce'], static::STATE);


### PR DESCRIPTION
## Summary of Changes

This PR adds `LtiAssignmentsGradesService::updateLineitem()` and updates the `LtiServiceConnector` to handle `PUT` requests. It also updates the `ServiceRequest` class to add `Content-Type` to `PUT` and `POST` requests.

## Testing

I applied the changes in this branch to my local environment (see [PR #6521](https://github.com/packbackbooks/questions/pull/6521) in the `questions` repo) and verified that, when updating posting requirements with GBS frequency set to `auto`, lineitems in Canvas updated as expected.

- [ ] I have added automated tests for my changes
