### PR TITLE
Fix invalid request when specifying no custom params

### DIFF
--- a/src/LtiDeepLinkResource.php
+++ b/src/LtiDeepLinkResource.php
@@ -110,8 +110,7 @@ class LtiDeepLinkResource
             'url' => $this->url,
             'presentation' => [
                 'documentTarget' => $this->target,
-            ],
-            'custom' => $this->custom_params,
+            ]
         ];
         if(!empty($this->custom_params)) {
             $resource['custom'] = $this->custom_params;

--- a/src/LtiDeepLinkResource.php
+++ b/src/LtiDeepLinkResource.php
@@ -9,7 +9,7 @@ class LtiDeepLinkResource
     private $text;
     private $url;
     private $lineitem;
-    private $custom_params = [];
+    private $custom_params = (object) null;
     private $target = 'iframe';
 
     public static function new()

--- a/src/LtiDeepLinkResource.php
+++ b/src/LtiDeepLinkResource.php
@@ -110,9 +110,9 @@ class LtiDeepLinkResource
             'url' => $this->url,
             'presentation' => [
                 'documentTarget' => $this->target,
-            ]
+            ],
         ];
-        if(!empty($this->custom_params)) {
+        if (!empty($this->custom_params)) {
             $resource['custom'] = $this->custom_params;
         }
         if ($this->lineitem !== null) {

--- a/src/LtiDeepLinkResource.php
+++ b/src/LtiDeepLinkResource.php
@@ -9,7 +9,7 @@ class LtiDeepLinkResource
     private $text;
     private $url;
     private $lineitem;
-    private $custom_params = (object) null;
+    private $custom_params = [];
     private $target = 'iframe';
 
     public static function new()
@@ -113,6 +113,9 @@ class LtiDeepLinkResource
             ],
             'custom' => $this->custom_params,
         ];
+        if(!empty($this->custom_params)) {
+            $resource['custom'] = $this->custom_params;
+        }
         if ($this->lineitem !== null) {
             $resource['lineItem'] = [
                 'scoreMaximum' => $this->lineitem->getScoreMaximum(),

--- a/tests/LtiDeepLinkResourceTest.php
+++ b/tests/LtiDeepLinkResourceTest.php
@@ -147,7 +147,6 @@ class LtiDeepLinkResourceTest extends TestCase
             'presentation' => [
                 'documentTarget' => 'iframe',
             ],
-            'custom' => [],
             'lineItem' => [
                 'scoreMaximum' => 80,
                 'label' => 'lineitem_label',
@@ -167,5 +166,12 @@ class LtiDeepLinkResourceTest extends TestCase
         $result = $this->deepLinkResource->toArray();
 
         $this->assertEquals($expected, $result);
+        
+        // Test again with custom params
+        $expected['custom'] = ['a_key' => 'a_value'];
+        $this->deepLinkResource->setCustomParams(['a_key' => 'a_value']);
+        $result = $this->deepLinkResource->toArray();
+        $this->assertEquals($expected, $result);
+        
     }
 }

--- a/tests/LtiDeepLinkResourceTest.php
+++ b/tests/LtiDeepLinkResourceTest.php
@@ -154,9 +154,9 @@ class LtiDeepLinkResourceTest extends TestCase
         ];
         $lineitem = Mockery::mock(LtiLineitem::class);
         $lineitem->shouldReceive('getScoreMaximum')
-            ->once()->andReturn($expected['lineItem']['scoreMaximum']);
+            ->twice()->andReturn($expected['lineItem']['scoreMaximum']);
         $lineitem->shouldReceive('getLabel')
-            ->once()->andReturn($expected['lineItem']['label']);
+            ->twice()->andReturn($expected['lineItem']['label']);
 
         $this->deepLinkResource->setTitle($expected['title']);
         $this->deepLinkResource->setText($expected['text']);

--- a/tests/LtiDeepLinkResourceTest.php
+++ b/tests/LtiDeepLinkResourceTest.php
@@ -166,12 +166,11 @@ class LtiDeepLinkResourceTest extends TestCase
         $result = $this->deepLinkResource->toArray();
 
         $this->assertEquals($expected, $result);
-        
+
         // Test again with custom params
         $expected['custom'] = ['a_key' => 'a_value'];
         $this->deepLinkResource->setCustomParams(['a_key' => 'a_value']);
         $result = $this->deepLinkResource->toArray();
         $this->assertEquals($expected, $result);
-        
     }
 }


### PR DESCRIPTION
## Summary of Changes

The current default value for $custom_params would be serialized into an array, which would make the request uncompliant to the specification and can lead to issues because the platform expects an object. Casting a null object will instead be serialized into an empty object which it is supposed to be.

## Testing

I haven't done any automatic testing but setting $custom_params to this value using setCustomParams fixed the issue for us and if you don't trust us you can manually test the behavior by simple evaluating `json_encode((object) null) === '{}'`

- [ ] I have added automated tests for my changes
