### PR TITLE
PODB-603: Update error message for missing registration

### DIFF
--- a/src/LtiMessageLaunch.php
+++ b/src/LtiMessageLaunch.php
@@ -283,8 +283,13 @@ class LtiMessageLaunch
         return $this->launch_id;
     }
 
-    public static function getMissingRegistrationErrorMsg(string $issuerUrl, string $clientId): string
+    public static function getMissingRegistrationErrorMsg(string $issuerUrl, ?string $clientId = null): string
     {
+        // Guard against client ID being null
+        if (!isset($clientId)) {
+            $clientId = '(N/A)';
+        }
+
         $search = [':issuerUrl', ':clientId'];
         $replace = [$issuerUrl, $clientId];
 

--- a/src/LtiMessageLaunch.php
+++ b/src/LtiMessageLaunch.php
@@ -28,7 +28,14 @@ class LtiMessageLaunch
     public const ERR_INVALID_ID_TOKEN = 'Invalid id_token, JWT must contain 3 parts';
     public const ERR_MISSING_NONCE = 'Missing Nonce.';
     public const ERR_INVALID_NONCE = 'Invalid Nonce.';
-    public const ERR_MISSING_REGISTRATION = 'Registration not found. Please have your admin confirm your Issuer URL, client ID, and deployment ID.';
+
+    /**
+     * :issuerUrl and :clientId are used to substitute the queried issuerUrl
+     * and clientId. Do not change those substrings without changing how the
+     * error message is built.
+     */
+    public const ERR_MISSING_REGISTRATION = 'LTI 1.3 Registration not found for Issuer :issuerUrl and Client ID :clientId. Please make sure the LMS has provided the right information, and that the LMS has been registered correctly in the tool.';
+
     public const ERR_CLIENT_NOT_REGISTERED = 'Client id not registered for this issuer.';
     public const ERR_NO_KID = 'No KID specified in the JWT Header.';
     public const ERR_INVALID_SIGNATURE = 'Invalid signature on id_token';
@@ -276,6 +283,14 @@ class LtiMessageLaunch
         return $this->launch_id;
     }
 
+    public function getMissingRegistrationErrorMsg(string $issuerUrl, string $clientId): string
+    {
+        $search = [':issuerUrl', ':clientId'];
+        $replace = [$issuerUrl, $clientId];
+
+        return str_replace($search, $replace, static::ERR_MISSING_REGISTRATION);
+    }
+
     private function getPublicKey()
     {
         $request = new ServiceRequest(
@@ -403,15 +418,16 @@ class LtiMessageLaunch
     private function validateRegistration()
     {
         // Find registration.
-        $client_id = is_array($this->jwt['body']['aud']) ? $this->jwt['body']['aud'][0] : $this->jwt['body']['aud'];
-        $this->registration = $this->db->findRegistrationByIssuer($this->jwt['body']['iss'], $client_id);
+        $clientId = is_array($this->jwt['body']['aud']) ? $this->jwt['body']['aud'][0] : $this->jwt['body']['aud'];
+        $issuerUrl = $this->jwt['body']['iss'];
+        $this->registration = $this->db->findRegistrationByIssuer($issuerUrl, $clientId);
 
         if (empty($this->registration)) {
-            throw new LtiException(static::ERR_MISSING_REGISTRATION);
+            throw new LtiException($this->getMissingRegistrationErrorMsg($issuerUrl, $clientId));
         }
 
         // Check client id.
-        if ($client_id !== $this->registration->getClientId()) {
+        if ($clientId !== $this->registration->getClientId()) {
             // Client not registered.
             throw new LtiException(static::ERR_CLIENT_NOT_REGISTERED);
         }

--- a/src/LtiMessageLaunch.php
+++ b/src/LtiMessageLaunch.php
@@ -283,7 +283,7 @@ class LtiMessageLaunch
         return $this->launch_id;
     }
 
-    public function getMissingRegistrationErrorMsg(string $issuerUrl, string $clientId): string
+    public static function getMissingRegistrationErrorMsg(string $issuerUrl, string $clientId): string
     {
         $search = [':issuerUrl', ':clientId'];
         $replace = [$issuerUrl, $clientId];

--- a/tests/LtiMessageLaunchTest.php
+++ b/tests/LtiMessageLaunchTest.php
@@ -294,7 +294,8 @@ class LtiMessageLaunchTest extends TestCase
             ->once()->andReturn();
 
         $this->expectException(LtiException::class);
-        $this->expectExceptionMessage(LtiMessageLaunch::ERR_MISSING_REGISTRATION);
+        $expectedMsg = $this->messageLaunch->getMissingRegistrationErrorMsg($this->issuer['issuer'], $this->issuer['client_id']);
+        $this->expectExceptionMessage($expectedMsg);
 
         $actual = $this->messageLaunch->validate($payload);
     }


### PR DESCRIPTION
## Summary of Changes

This PR updates how we generate the error message for a missing registration, adding the issuer URL and client ID to the message as per [the Jira ticket](https://packback.atlassian.net/browse/PODB-603).

## Testing

I manually verified that the error message has the issuer URL and client ID appropriately substituted in the message:

<details><summary>Screenshot</summary>

Note: I got this error to throw by commenting out the `if ()` logic surrounding the exception.

![Screenshot from 2022-07-20 14-29-44](https://user-images.githubusercontent.com/29388364/180069567-15029bb4-8209-4c22-a1a0-e7214fa496f3.png)

</details>

- [X] I have added automated tests for my changes
- [X] I ran `composer test` before opening this PR
- [X] I ran `composer lint-fix` before opening this PR
