### PR TITLE
Add icon to deep link resource

### DIFF
--- a/src/LtiDeepLinkResource.php
+++ b/src/LtiDeepLinkResource.php
@@ -137,7 +137,7 @@ class LtiDeepLinkResource
     /**
      * @return LtiDeepLinkResourceIcon
      */
-    public function getIcon()
+    public function getIcon(): LtiDeepLinkResourceIcon
     {
         return $this->icon;
     }

--- a/src/LtiDeepLinkResource.php
+++ b/src/LtiDeepLinkResource.php
@@ -157,7 +157,7 @@ class LtiDeepLinkResource
     /**
      * @return LtiDeepLinkResourceIcon
      */
-    public function getThumbnail()
+    public function getThumbnail(): LtiDeepLinkResourceIcon
     {
         return $this->thumbnail;
     }

--- a/src/LtiDeepLinkResource.php
+++ b/src/LtiDeepLinkResource.php
@@ -147,7 +147,7 @@ class LtiDeepLinkResource
      *
      * @return $this
      */
-    public function setThumbnail($thumbnail)
+    public function setThumbnail(LtiDeepLinkResourceIcon $thumbnail)
     {
         $this->thumbnail = $thumbnail;
 

--- a/src/LtiDeepLinkResource.php
+++ b/src/LtiDeepLinkResource.php
@@ -127,7 +127,7 @@ class LtiDeepLinkResource
      *
      * @return $this
      */
-    public function setIcon($icon)
+    public function setIcon(LtiDeepLinkResourceIcon $icon)
     {
         $this->icon = $icon;
 

--- a/src/LtiDeepLinkResource.php
+++ b/src/LtiDeepLinkResource.php
@@ -9,19 +9,32 @@ class LtiDeepLinkResource
     private $text;
     private $url;
     private $lineitem;
+    private $icon;
+    private $thumbnail;
     private $custom_params = [];
     private $target = 'iframe';
 
+    /**
+     * @return LtiDeepLinkResource
+     */
     public static function new()
     {
         return new LtiDeepLinkResource();
     }
 
+    /**
+     * @return string
+     */
     public function getType()
     {
         return $this->type;
     }
 
+    /**
+     * @param $value string
+     *
+     * @return $this
+     */
     public function setType($value)
     {
         $this->type = $value;
@@ -29,11 +42,19 @@ class LtiDeepLinkResource
         return $this;
     }
 
+    /**
+     * @return string
+     */
     public function getTitle()
     {
         return $this->title;
     }
 
+    /**
+     * @param $value string
+     *
+     * @return $this
+     */
     public function setTitle($value)
     {
         $this->title = $value;
@@ -41,11 +62,19 @@ class LtiDeepLinkResource
         return $this;
     }
 
+    /**
+     * @return string
+     */
     public function getText()
     {
         return $this->text;
     }
 
+    /**
+     * @param $value string
+     *
+     * @return $this
+     */
     public function setText($value)
     {
         $this->text = $value;
@@ -53,11 +82,19 @@ class LtiDeepLinkResource
         return $this;
     }
 
+    /**
+     * @return string
+     */
     public function getUrl()
     {
         return $this->url;
     }
 
+    /**
+     * @param $value string
+     *
+     * @return $this
+     */
     public function setUrl($value)
     {
         $this->url = $value;
@@ -65,23 +102,79 @@ class LtiDeepLinkResource
         return $this;
     }
 
+    /**
+     * @return LtiLineitem
+     */
     public function getLineitem()
     {
         return $this->lineitem;
     }
 
-    public function setLineitem(LtiLineitem $value)
+    /**
+     * @param $value LtiLineitem
+     *
+     * @return $this
+     */
+    public function setLineitem($value)
     {
         $this->lineitem = $value;
 
         return $this;
     }
 
+    /**
+     * @param $icon LtiDeepLinkResourceIcon
+     *
+     * @return $this
+     */
+    public function setIcon($icon)
+    {
+        $this->icon = $icon;
+
+        return $this;
+    }
+
+    /**
+     * @return LtiDeepLinkResourceIcon
+     */
+    public function getIcon()
+    {
+        return $this->icon;
+    }
+
+    /**
+     * @param $thumbnail LtiDeepLinkResourceIcon
+     *
+     * @return $this
+     */
+    public function setThumbnail($thumbnail)
+    {
+        $this->thumbnail = $thumbnail;
+
+        return $this;
+    }
+
+    /**
+     * @return LtiDeepLinkResourceIcon
+     */
+    public function getThumbnail()
+    {
+        return $this->thumbnail;
+    }
+
+    /**
+     * @return array
+     */
     public function getCustomParams()
     {
         return $this->custom_params;
     }
 
+    /**
+     * @param $value array
+     *
+     * @return $this
+     */
     public function setCustomParams($value)
     {
         $this->custom_params = $value;
@@ -89,11 +182,19 @@ class LtiDeepLinkResource
         return $this;
     }
 
+    /**
+     * @return string
+     */
     public function getTarget()
     {
         return $this->target;
     }
 
+    /**
+     * @param $value string
+     *
+     * @return $this
+     */
     public function setTarget($value)
     {
         $this->target = $value;
@@ -101,6 +202,9 @@ class LtiDeepLinkResource
         return $this;
     }
 
+    /**
+     * @return array
+     */
     public function toArray()
     {
         $resource = [
@@ -114,6 +218,12 @@ class LtiDeepLinkResource
         ];
         if (!empty($this->custom_params)) {
             $resource['custom'] = $this->custom_params;
+        }
+        if (isset($this->icon)) {
+            $resource['icon'] = $this->icon->toArray();
+        }
+        if (isset($this->thumbnail)) {
+            $resource['thumbnail'] = $this->thumbnail->toArray();
         }
         if ($this->lineitem !== null) {
             $resource['lineItem'] = [

--- a/src/LtiDeepLinkResource.php
+++ b/src/LtiDeepLinkResource.php
@@ -8,204 +8,126 @@ class LtiDeepLinkResource
     private $title;
     private $text;
     private $url;
-    private $lineitem;
+    private $line_item;
     private $icon;
     private $thumbnail;
     private $custom_params = [];
     private $target = 'iframe';
 
-    /**
-     * @return LtiDeepLinkResource
-     */
-    public static function new()
+    public static function new(): LtiDeepLinkResource
     {
         return new LtiDeepLinkResource();
     }
 
-    /**
-     * @return string
-     */
-    public function getType()
+    public function getType(): string
     {
         return $this->type;
     }
 
-    /**
-     * @param $value string
-     *
-     * @return $this
-     */
-    public function setType($value)
+    public function setType(string $value): LtiDeepLinkResource
     {
         $this->type = $value;
 
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getTitle()
+    public function getTitle(): ?string
     {
         return $this->title;
     }
 
-    /**
-     * @param $value string
-     *
-     * @return $this
-     */
-    public function setTitle($value)
+    public function setTitle(?string $value): LtiDeepLinkResource
     {
         $this->title = $value;
 
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getText()
+    public function getText(): ?string
     {
         return $this->text;
     }
 
-    /**
-     * @param $value string
-     *
-     * @return $this
-     */
-    public function setText($value)
+    public function setText(?string $value): LtiDeepLinkResource
     {
         $this->text = $value;
 
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getUrl()
+    public function getUrl(): ?string
     {
         return $this->url;
     }
 
-    /**
-     * @param $value string
-     *
-     * @return $this
-     */
-    public function setUrl($value)
+    public function setUrl(?string $value): LtiDeepLinkResource
     {
         $this->url = $value;
 
         return $this;
     }
 
-    /**
-     * @return LtiLineitem
-     */
-    public function getLineitem()
+    public function getLineItem(): ?LtiLineitem
     {
-        return $this->lineitem;
+        return $this->line_item;
     }
 
-    /**
-     * @param $value LtiLineitem
-     *
-     * @return $this
-     */
-    public function setLineitem(LtiLineitem $value)
+    public function setLineItem(?LtiLineitem $value): LtiDeepLinkResource
     {
-        $this->lineitem = $value;
+        $this->line_item = $value;
 
         return $this;
     }
 
-    /**
-     * @param $icon LtiDeepLinkResourceIcon
-     *
-     * @return $this
-     */
-    public function setIcon(LtiDeepLinkResourceIcon $icon)
+    public function setIcon(?LtiDeepLinkResourceIcon $icon): LtiDeepLinkResource
     {
         $this->icon = $icon;
 
         return $this;
     }
 
-    /**
-     * @return LtiDeepLinkResourceIcon
-     */
-    public function getIcon(): LtiDeepLinkResourceIcon
+    public function getIcon(): ?LtiDeepLinkResourceIcon
     {
         return $this->icon;
     }
 
-    /**
-     * @param $thumbnail LtiDeepLinkResourceIcon
-     *
-     * @return $this
-     */
-    public function setThumbnail(LtiDeepLinkResourceIcon $thumbnail)
+    public function setThumbnail(?LtiDeepLinkResourceIcon $thumbnail): LtiDeepLinkResource
     {
         $this->thumbnail = $thumbnail;
 
         return $this;
     }
 
-    /**
-     * @return LtiDeepLinkResourceIcon
-     */
-    public function getThumbnail(): LtiDeepLinkResourceIcon
+    public function getThumbnail(): ?LtiDeepLinkResourceIcon
     {
         return $this->thumbnail;
     }
 
-    /**
-     * @return array
-     */
-    public function getCustomParams()
+    public function getCustomParams(): array
     {
         return $this->custom_params;
     }
 
-    /**
-     * @param $value array
-     *
-     * @return $this
-     */
-    public function setCustomParams($value)
+    public function setCustomParams(array $value): LtiDeepLinkResource
     {
         $this->custom_params = $value;
 
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getTarget()
+    public function getTarget(): string
     {
         return $this->target;
     }
 
-    /**
-     * @param $value string
-     *
-     * @return $this
-     */
-    public function setTarget($value)
+    public function setTarget(string $value): LtiDeepLinkResource
     {
         $this->target = $value;
 
         return $this;
     }
 
-    /**
-     * @return array
-     */
-    public function toArray()
+    public function toArray(): array
     {
         $resource = [
             'type' => $this->type,
@@ -225,10 +147,10 @@ class LtiDeepLinkResource
         if (isset($this->thumbnail)) {
             $resource['thumbnail'] = $this->thumbnail->toArray();
         }
-        if ($this->lineitem !== null) {
+        if ($this->line_item !== null) {
             $resource['lineItem'] = [
-                'scoreMaximum' => $this->lineitem->getScoreMaximum(),
-                'label' => $this->lineitem->getLabel(),
+                'scoreMaximum' => $this->line_item->getScoreMaximum(),
+                'label' => $this->line_item->getLabel(),
             ];
         }
 

--- a/src/LtiDeepLinkResource.php
+++ b/src/LtiDeepLinkResource.php
@@ -115,7 +115,7 @@ class LtiDeepLinkResource
      *
      * @return $this
      */
-    public function setLineitem($value)
+    public function setLineitem(LtiLineitem $value)
     {
         $this->lineitem = $value;
 

--- a/src/LtiDeepLinkResourceIcon.php
+++ b/src/LtiDeepLinkResourceIcon.php
@@ -8,14 +8,14 @@ class LtiDeepLinkResourceIcon
     private $width;
     private $height;
 
-    public function __construct(string $url, ?int $width = null, ?int $height = null)
+    public function __construct(string $url, int $width, int $height)
     {
         $this->url = $url;
         $this->width = $width;
         $this->height = $height;
     }
 
-    public static function new(string $url, ?int $width = null, ?int $height = null): LtiDeepLinkResourceIcon
+    public static function new(string $url, int $width, int $height): LtiDeepLinkResourceIcon
     {
         return new LtiDeepLinkResourceIcon($url, $width, $height);
     }
@@ -32,26 +32,26 @@ class LtiDeepLinkResourceIcon
         return $this->url;
     }
 
-    public function setWidth(?int $width): LtiDeepLinkResourceIcon
+    public function setWidth(int $width): LtiDeepLinkResourceIcon
     {
         $this->width = $width;
 
         return $this;
     }
 
-    public function getWidth(): ?int
+    public function getWidth(): int
     {
         return $this->width;
     }
 
-    public function setHeight(?int $height): LtiDeepLinkResourceIcon
+    public function setHeight(int $height): LtiDeepLinkResourceIcon
     {
         $this->height = $height;
 
         return $this;
     }
 
-    public function getHeight(): ?int
+    public function getHeight(): int
     {
         return $this->height;
     }

--- a/src/LtiDeepLinkResourceIcon.php
+++ b/src/LtiDeepLinkResourceIcon.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Packback\Lti1p3;
+
+class LtiDeepLinkResourceIcon
+{
+    private $url;
+    private $width;
+    private $height;
+
+    /**
+     * @return LtiDeepLinkResourceIcon
+     */
+    public static function new()
+    {
+        return new LtiDeepLinkResourceIcon();
+    }
+
+    /**
+     * @param $url string
+     *
+     * @return $this
+     */
+    public function setUrl($url)
+    {
+        $this->url = $url;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUrl()
+    {
+        return $this->url;
+    }
+
+    /**
+     * @param $width int
+     *
+     * @return $this
+     */
+    public function setWidth($width)
+    {
+        $this->width = $width;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getWidth()
+    {
+        return $this->width;
+    }
+
+    /**
+     * @param $height int
+     *
+     * @return $this
+     */
+    public function setHeight($height)
+    {
+        $this->height = $height;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getHeight()
+    {
+        return $this->height;
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            'url' => $this->url,
+            'width' => $this->width,
+            'height' => $this->height,
+        ];
+    }
+}

--- a/src/LtiDeepLinkResourceIcon.php
+++ b/src/LtiDeepLinkResourceIcon.php
@@ -8,77 +8,54 @@ class LtiDeepLinkResourceIcon
     private $width;
     private $height;
 
-    /**
-     * @return LtiDeepLinkResourceIcon
-     */
-    public static function new()
+    public function __construct(string $url, ?int $width = null, ?int $height = null)
     {
-        return new LtiDeepLinkResourceIcon();
+        $this->url = $url;
+        $this->width = $width;
+        $this->height = $height;
     }
 
-    /**
-     * @param $url string
-     *
-     * @return $this
-     */
-    public function setUrl($url)
+    public static function new(): LtiDeepLinkResourceIcon
+    {
+        return new LtiDeepLinkResourceIcon('');
+    }
+
+    public function setUrl(string $url): LtiDeepLinkResourceIcon
     {
         $this->url = $url;
 
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getUrl()
+    public function getUrl(): string
     {
         return $this->url;
     }
 
-    /**
-     * @param $width int
-     *
-     * @return $this
-     */
-    public function setWidth($width)
+    public function setWidth(?int $width): LtiDeepLinkResourceIcon
     {
         $this->width = $width;
 
         return $this;
     }
 
-    /**
-     * @return int
-     */
-    public function getWidth()
+    public function getWidth(): ?int
     {
         return $this->width;
     }
 
-    /**
-     * @param $height int
-     *
-     * @return $this
-     */
-    public function setHeight($height)
+    public function setHeight(?int $height): LtiDeepLinkResourceIcon
     {
         $this->height = $height;
 
         return $this;
     }
 
-    /**
-     * @return int
-     */
-    public function getHeight()
+    public function getHeight(): ?int
     {
         return $this->height;
     }
 
-    /**
-     * @return array
-     */
     public function toArray(): array
     {
         return [

--- a/src/LtiDeepLinkResourceIcon.php
+++ b/src/LtiDeepLinkResourceIcon.php
@@ -79,7 +79,7 @@ class LtiDeepLinkResourceIcon
     /**
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         return [
             'url' => $this->url,

--- a/src/LtiDeepLinkResourceIcon.php
+++ b/src/LtiDeepLinkResourceIcon.php
@@ -15,9 +15,9 @@ class LtiDeepLinkResourceIcon
         $this->height = $height;
     }
 
-    public static function new(): LtiDeepLinkResourceIcon
+    public static function new(string $url, ?int $width = null, ?int $height = null): LtiDeepLinkResourceIcon
     {
-        return new LtiDeepLinkResourceIcon('');
+        return new LtiDeepLinkResourceIcon($url, $width, $height);
     }
 
     public function setUrl(string $url): LtiDeepLinkResourceIcon

--- a/tests/LtiDeepLinkResourceIconTest.php
+++ b/tests/LtiDeepLinkResourceIconTest.php
@@ -27,7 +27,7 @@ class LtiDeepLinkResourceIconTest extends TestCase
     {
         $result = $this->deepLinkResourceIcon->getUrl();
 
-        $this->assertEquals(null, $result);
+        $this->assertNull($result);
     }
 
     public function testItSetsUrl()

--- a/tests/LtiDeepLinkResourceIconTest.php
+++ b/tests/LtiDeepLinkResourceIconTest.php
@@ -8,7 +8,7 @@ class LtiDeepLinkResourceIconTest extends TestCase
 {
     public function setUp(): void
     {
-        $this->deepLinkResourceIcon = new LtiDeepLinkResourceIcon();
+        $this->deepLinkResourceIcon = new LtiDeepLinkResourceIcon('https://example.com');
     }
 
     public function testItInstantiates()
@@ -27,7 +27,7 @@ class LtiDeepLinkResourceIconTest extends TestCase
     {
         $result = $this->deepLinkResourceIcon->getUrl();
 
-        $this->assertNull($result);
+        $this->assertEquals('https://example.com', $result);
     }
 
     public function testItSetsUrl()

--- a/tests/LtiDeepLinkResourceIconTest.php
+++ b/tests/LtiDeepLinkResourceIconTest.php
@@ -59,7 +59,7 @@ class LtiDeepLinkResourceIconTest extends TestCase
     {
         $result = $this->deepLinkResourceIcon->getHeight();
 
-        $this->assertEquals(null, $result);
+        $this->assertNull($result);
     }
 
     public function testItSetsHeight()

--- a/tests/LtiDeepLinkResourceIconTest.php
+++ b/tests/LtiDeepLinkResourceIconTest.php
@@ -8,7 +8,8 @@ class LtiDeepLinkResourceIconTest extends TestCase
 {
     public function setUp(): void
     {
-        $this->deepLinkResourceIcon = new LtiDeepLinkResourceIcon('https://example.com');
+        $this->imageUrl = 'https://example.com/image.png';
+        $this->deepLinkResourceIcon = new LtiDeepLinkResourceIcon($this->imageUrl);
     }
 
     public function testItInstantiates()
@@ -18,7 +19,7 @@ class LtiDeepLinkResourceIconTest extends TestCase
 
     public function testItCreatesANewInstance()
     {
-        $deepLinkResource = LtiDeepLinkResourceIcon::new();
+        $deepLinkResource = LtiDeepLinkResourceIcon::new($this->imageUrl);
 
         $this->assertInstanceOf(LtiDeepLinkResourceIcon::class, $deepLinkResource);
     }
@@ -27,7 +28,7 @@ class LtiDeepLinkResourceIconTest extends TestCase
     {
         $result = $this->deepLinkResourceIcon->getUrl();
 
-        $this->assertEquals('https://example.com', $result);
+        $this->assertEquals($this->imageUrl, $result);
     }
 
     public function testItSetsUrl()
@@ -74,7 +75,7 @@ class LtiDeepLinkResourceIconTest extends TestCase
     public function testItCastsToArray()
     {
         $expected = [
-            'url' => 'https://example.com/icon.png',
+            'url' => $this->imageUrl,
             'width' => 100,
             'height' => 200,
         ];

--- a/tests/LtiDeepLinkResourceIconTest.php
+++ b/tests/LtiDeepLinkResourceIconTest.php
@@ -43,7 +43,7 @@ class LtiDeepLinkResourceIconTest extends TestCase
     {
         $result = $this->deepLinkResourceIcon->getWidth();
 
-        $this->assertEquals(null, $result);
+        $this->assertNull($result);
     }
 
     public function testItSetsWidth()

--- a/tests/LtiDeepLinkResourceIconTest.php
+++ b/tests/LtiDeepLinkResourceIconTest.php
@@ -9,7 +9,7 @@ class LtiDeepLinkResourceIconTest extends TestCase
     public function setUp(): void
     {
         $this->imageUrl = 'https://example.com/image.png';
-        $this->deepLinkResourceIcon = new LtiDeepLinkResourceIcon($this->imageUrl);
+        $this->deepLinkResourceIcon = new LtiDeepLinkResourceIcon($this->imageUrl, 1, 2);
     }
 
     public function testItInstantiates()
@@ -19,7 +19,7 @@ class LtiDeepLinkResourceIconTest extends TestCase
 
     public function testItCreatesANewInstance()
     {
-        $deepLinkResource = LtiDeepLinkResourceIcon::new($this->imageUrl);
+        $deepLinkResource = LtiDeepLinkResourceIcon::new($this->imageUrl, 100, 200);
 
         $this->assertInstanceOf(LtiDeepLinkResourceIcon::class, $deepLinkResource);
     }
@@ -44,7 +44,7 @@ class LtiDeepLinkResourceIconTest extends TestCase
     {
         $result = $this->deepLinkResourceIcon->getWidth();
 
-        $this->assertNull($result);
+        $this->assertEquals(1, $result);
     }
 
     public function testItSetsWidth()
@@ -60,7 +60,7 @@ class LtiDeepLinkResourceIconTest extends TestCase
     {
         $result = $this->deepLinkResourceIcon->getHeight();
 
-        $this->assertNull($result);
+        $this->assertEquals(2, $result);
     }
 
     public function testItSetsHeight()

--- a/tests/LtiDeepLinkResourceIconTest.php
+++ b/tests/LtiDeepLinkResourceIconTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests;
+
+use Packback\Lti1p3\LtiDeepLinkResourceIcon;
+
+class LtiDeepLinkResourceIconTest extends TestCase
+{
+    public function setUp(): void
+    {
+        $this->deepLinkResourceIcon = new LtiDeepLinkResourceIcon();
+    }
+
+    public function testItInstantiates()
+    {
+        $this->assertInstanceOf(LtiDeepLinkResourceIcon::class, $this->deepLinkResourceIcon);
+    }
+
+    public function testItCreatesANewInstance()
+    {
+        $deepLinkResource = LtiDeepLinkResourceIcon::new();
+
+        $this->assertInstanceOf(LtiDeepLinkResourceIcon::class, $deepLinkResource);
+    }
+
+    public function testItGetsUrl()
+    {
+        $result = $this->deepLinkResourceIcon->getUrl();
+
+        $this->assertEquals(null, $result);
+    }
+
+    public function testItSetsUrl()
+    {
+        $expected = 'expected';
+
+        $this->deepLinkResourceIcon->setUrl($expected);
+
+        $this->assertEquals($expected, $this->deepLinkResourceIcon->getUrl());
+    }
+
+    public function testItGetsWidth()
+    {
+        $result = $this->deepLinkResourceIcon->getWidth();
+
+        $this->assertEquals(null, $result);
+    }
+
+    public function testItSetsWidth()
+    {
+        $expected = 300;
+
+        $this->deepLinkResourceIcon->setWidth($expected);
+
+        $this->assertEquals($expected, $this->deepLinkResourceIcon->getWidth());
+    }
+
+    public function testItGetsHeight()
+    {
+        $result = $this->deepLinkResourceIcon->getHeight();
+
+        $this->assertEquals(null, $result);
+    }
+
+    public function testItSetsHeight()
+    {
+        $expected = 400;
+
+        $this->deepLinkResourceIcon->setHeight($expected);
+
+        $this->assertEquals($expected, $this->deepLinkResourceIcon->getHeight());
+    }
+
+    public function testItCastsToArray()
+    {
+        $expected = [
+            'url' => 'https://example.com/icon.png',
+            'width' => 100,
+            'height' => 200,
+        ];
+
+        $this->deepLinkResourceIcon->setUrl($expected['url']);
+        $this->deepLinkResourceIcon->setWidth($expected['width']);
+        $this->deepLinkResourceIcon->setHeight($expected['height']);
+
+        $result = $this->deepLinkResourceIcon->toArray();
+
+        $this->assertEquals($expected, $result);
+    }
+}

--- a/tests/LtiDeepLinkResourceTest.php
+++ b/tests/LtiDeepLinkResourceTest.php
@@ -185,12 +185,12 @@ class LtiDeepLinkResourceTest extends TestCase
             'icon' => [
                 'url' => $icon->getUrl(),
                 'width' => $icon->getWidth(),
-                'height' => $icon->getHeight()
+                'height' => $icon->getHeight(),
             ],
             'thumbnail' => [
                 'url' => $icon->getUrl(),
                 'width' => $icon->getWidth(),
-                'height' => $icon->getHeight()
+                'height' => $icon->getHeight(),
             ],
             'presentation' => [
                 'documentTarget' => 'iframe',
@@ -198,7 +198,7 @@ class LtiDeepLinkResourceTest extends TestCase
             'lineItem' => [
                 'scoreMaximum' => 80,
                 'label' => 'lineitem_label',
-            ]
+            ],
         ];
 
         $lineitem = Mockery::mock(LtiLineitem::class);

--- a/tests/LtiDeepLinkResourceTest.php
+++ b/tests/LtiDeepLinkResourceTest.php
@@ -172,7 +172,7 @@ class LtiDeepLinkResourceTest extends TestCase
 
     public function testItCastsToArray()
     {
-        $icon = (new LtiDeepLinkResourceIcon())
+        $icon = LtiDeepLinkResourceIcon::new()
             ->setUrl('a_url')
             ->setWidth(100)
             ->setHeight(200);

--- a/tests/LtiDeepLinkResourceTest.php
+++ b/tests/LtiDeepLinkResourceTest.php
@@ -92,7 +92,7 @@ class LtiDeepLinkResourceTest extends TestCase
 
     public function testItGetsLineitem()
     {
-        $result = $this->deepLinkResource->getLineitem();
+        $result = $this->deepLinkResource->getLineItem();
 
         $this->assertNull($result);
     }
@@ -101,9 +101,9 @@ class LtiDeepLinkResourceTest extends TestCase
     {
         $expected = Mockery::mock(LtiLineitem::class);
 
-        $this->deepLinkResource->setLineitem($expected);
+        $this->deepLinkResource->setLineItem($expected);
 
-        $this->assertEquals($expected, $this->deepLinkResource->getLineitem());
+        $this->assertEquals($expected, $this->deepLinkResource->getLineItem());
     }
 
     public function testItGetsIcon()
@@ -147,7 +147,7 @@ class LtiDeepLinkResourceTest extends TestCase
 
     public function testItSetsCustomParams()
     {
-        $expected = 'expected';
+        $expected = ['a_key' => 'a_value'];
 
         $this->deepLinkResource->setCustomParams($expected);
 
@@ -212,7 +212,7 @@ class LtiDeepLinkResourceTest extends TestCase
         $this->deepLinkResource->setUrl($expected['url']);
         $this->deepLinkResource->setIcon($icon);
         $this->deepLinkResource->setThumbnail($icon);
-        $this->deepLinkResource->setLineitem($lineitem);
+        $this->deepLinkResource->setLineItem($lineitem);
 
         $result = $this->deepLinkResource->toArray();
 

--- a/tests/LtiDeepLinkResourceTest.php
+++ b/tests/LtiDeepLinkResourceTest.php
@@ -11,6 +11,7 @@ class LtiDeepLinkResourceTest extends TestCase
 {
     public function setUp(): void
     {
+        $this->imageUrl = 'https://example.com/image.png';
         $this->deepLinkResource = new LtiDeepLinkResource();
     }
 
@@ -172,10 +173,7 @@ class LtiDeepLinkResourceTest extends TestCase
 
     public function testItCastsToArray()
     {
-        $icon = LtiDeepLinkResourceIcon::new()
-            ->setUrl('a_url')
-            ->setWidth(100)
-            ->setHeight(200);
+        $icon = LtiDeepLinkResourceIcon::new($this->imageUrl, 100, 200);
 
         $expected = [
             'type' => 'ltiResourceLink',

--- a/tests/LtiDeepLinkResourceTest.php
+++ b/tests/LtiDeepLinkResourceTest.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use Mockery;
 use Packback\Lti1p3\LtiDeepLinkResource;
+use Packback\Lti1p3\LtiDeepLinkResourceIcon;
 use Packback\Lti1p3\LtiLineitem;
 
 class LtiDeepLinkResourceTest extends TestCase
@@ -105,6 +106,38 @@ class LtiDeepLinkResourceTest extends TestCase
         $this->assertEquals($expected, $this->deepLinkResource->getLineitem());
     }
 
+    public function testItGetsIcon()
+    {
+        $result = $this->deepLinkResource->getIcon();
+
+        $this->assertNull($result);
+    }
+
+    public function testItSetsIcon()
+    {
+        $expected = Mockery::mock(LtiDeepLinkResourceIcon::class);
+
+        $this->deepLinkResource->setIcon($expected);
+
+        $this->assertEquals($expected, $this->deepLinkResource->getIcon());
+    }
+
+    public function testItGetsThumbnail()
+    {
+        $result = $this->deepLinkResource->getThumbnail();
+
+        $this->assertNull($result);
+    }
+
+    public function testItSetsThumbnail()
+    {
+        $expected = Mockery::mock(LtiDeepLinkResourceIcon::class);
+
+        $this->deepLinkResource->setThumbnail($expected);
+
+        $this->assertEquals($expected, $this->deepLinkResource->getThumbnail());
+    }
+
     public function testItGetsCustomParams()
     {
         $result = $this->deepLinkResource->getCustomParams();
@@ -139,19 +172,35 @@ class LtiDeepLinkResourceTest extends TestCase
 
     public function testItCastsToArray()
     {
+        $icon = (new LtiDeepLinkResourceIcon())
+            ->setUrl('a_url')
+            ->setWidth(100)
+            ->setHeight(200);
+
         $expected = [
             'type' => 'ltiResourceLink',
             'title' => 'a_title',
             'text' => 'a_text',
             'url' => 'a_url',
+            'icon' => [
+                'url' => $icon->getUrl(),
+                'width' => $icon->getWidth(),
+                'height' => $icon->getHeight()
+            ],
+            'thumbnail' => [
+                'url' => $icon->getUrl(),
+                'width' => $icon->getWidth(),
+                'height' => $icon->getHeight()
+            ],
             'presentation' => [
                 'documentTarget' => 'iframe',
             ],
             'lineItem' => [
                 'scoreMaximum' => 80,
                 'label' => 'lineitem_label',
-            ],
+            ]
         ];
+
         $lineitem = Mockery::mock(LtiLineitem::class);
         $lineitem->shouldReceive('getScoreMaximum')
             ->twice()->andReturn($expected['lineItem']['scoreMaximum']);
@@ -161,6 +210,8 @@ class LtiDeepLinkResourceTest extends TestCase
         $this->deepLinkResource->setTitle($expected['title']);
         $this->deepLinkResource->setText($expected['text']);
         $this->deepLinkResource->setUrl($expected['url']);
+        $this->deepLinkResource->setIcon($icon);
+        $this->deepLinkResource->setThumbnail($icon);
         $this->deepLinkResource->setLineitem($lineitem);
 
         $result = $this->deepLinkResource->toArray();


### PR DESCRIPTION
## Summary of Changes

The LtiDeepLinkResource was missing the url and thumbnail properties as described [inside the deep linking specification](https://www.imsglobal.org/spec/lti-dl/v2p0#deep-linking-response-example). This PR adds those properties and some more php-docs.

## Testing

I added tests for both the new class and the new properties

- [x] I have added automated tests for my changes
- [x] I ran `composer test` before opening this PR
- [x] I ran `composer lint-fix` before opening this PR
