### PR TITLE
PODB-612: Replace registration error with dynamic function.

### DIFF
--- a/src/LtiOidcLogin.php
+++ b/src/LtiOidcLogin.php
@@ -13,7 +13,6 @@ class LtiOidcLogin
     public const ERROR_MSG_LAUNCH_URL = 'No launch URL configured';
     public const ERROR_MSG_ISSUER = 'Could not find issuer';
     public const ERROR_MSG_LOGIN_HINT = 'Could not find login hint';
-    public const ERROR_MSG_REGISTRATION = 'Could not find registration details';
 
     private $db;
     private $cache;
@@ -113,11 +112,14 @@ class LtiOidcLogin
         }
 
         // Fetch Registration Details.
-        $registration = $this->db->findRegistrationByIssuer($request['iss'], $request['client_id'] ?? null);
+        $clientId = $request['client_id'] ?? null;
+        $registration = $this->db->findRegistrationByIssuer($request['iss'], $clientId);
 
         // Check we got something.
         if (empty($registration)) {
-            throw new OidcException(static::ERROR_MSG_REGISTRATION, 1);
+            $errorMsg = LtiMessageLaunch::getMissingRegistrationErrorMsg($request['iss'], $clientId);
+
+            throw new OidcException($errorMsg, 1);
         }
 
         // Return Registration.


### PR DESCRIPTION
## Summary of Changes

This PR replaces the error string "Could not find registration details" with the `LtiMessageLaunch::getMissingRegistrationErrorMsg()` function. This was meant to be implemented in #63, but I missed it due to the two original error strings being different.

## Testing

I copy+pasted the code in my local BE, forced the exception to always be thrown, and verified that the message appears when attempting to log in via an LTI 1.3 launch.

<details><summary>Screenshot</summary>

![Screenshot from 2022-07-28 13-12-24](https://user-images.githubusercontent.com/29388364/181608200-b443f5e5-7556-432f-83e8-7bf0bc88a0fd.png)

</details>