### PR TITLE
Update LtiServiceConnector.php

### DIFF
--- a/src/LtiServiceConnector.php
+++ b/src/LtiServiceConnector.php
@@ -153,7 +153,7 @@ class LtiServiceConnector implements ILtiServiceConnector
         ILtiRegistration $registration,
         array $scopes,
         IServiceRequest $request,
-        string $key = null,
+        string $key = null
     ): array {
         if ($request->getMethod() !== ServiceRequest::METHOD_GET) {
             throw new \Exception('An invalid method was specified by an LTI service requesting all items.');


### PR DESCRIPTION
## Summary of Changes

Removed unnecessary trailing comma in method parameter list. By this, PHP 7.4 can work with this file, too.
Would be the solution for my issue #66 
<!-- A few sentences describing the big picture of your changes. -->

## Testing

<!-- Describe how this PR has been tested, manually and automatically. -->
No new tests are necessary, and I ran the composer test and lint, but both create a lot of other errors on my system (like tmp/jwks.json does not exist or linting in files that I did not touch). 
I doubt this change can have any effects on existing tests or linting, however.

- [ ] I have added automated tests for my changes
- [ ] I ran `composer test` before opening this PR
- [ ] I ran `composer lint-fix` before opening this PR
