### PR TITLE
Issue #1 - Update Namespace and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,16 @@ A library used for building IMS-certified LTI 1.3 tool providers in PHP.
 
 This library allows a tool provider (your app) to receive LTI launches from a tool consumer (i.e. LMS). It validates LTI launches and lets an application interact with services like the Names Roles Provisioning Service (to fetch a roster for an LMS course) and Assignment Grades Service (to update grades for students in a course in the LMS).
 
-This library was forked from [IMSGlobal/lti-1-3-php-library](https://github.com/IMSGlobal/lti-1-3-php-library), initially created by @MartinLenord. [Packback](https://packback.co) found the library immensely helpful and extended it over the years. It has been rewritten by Packback to bring it into compliance with the standards set out by the PHP-FIG and the IMS LTI 1.3 Certification process. Packback actively uses and maintains this library.
-
+This library was forked from [packbackbooks/lti-1p3-tool](https://github.com/packbackbooks/lti-1p3-tool) created by [Packback](https://packback.io), which was in turn forked from [IMSGlobal/lti-1-3-php-library](https://github.com/IMSGlobal/lti-1-3-php-library), initially created by @MartinLenord.
 ## Installation
 
 Run:
 
 ```bash
-composer require packbackbooks/lti-1p3-tool
+composer require bnsoftware/lti-1p3-tool
 ```
 
-In your code, you will now be able to use classes in the `Packback\Lti1p3` namespace to access the library.
+In your code, you will now be able to use classes in the `BNSoftware\Lti1p3` namespace to access the library.
 
 ### Configure JWT
 
@@ -30,18 +29,18 @@ Firebase\JWT\JWT::$leeway = 5;
 
 This library uses three methods for storing and accessing data: cache, cookie, and database. All three must be implemented in order for the library to work. You may create your own custom implementations so long as they adhere to the following interfaces:
 
-- `Packback\Lti1p3\Interfaces\ICache`
-- `Packback\Lti1p3\Interfaces\ICookie`
-- `Packback\Lti1p3\Interfaces\IDatabase`
+- `BNSoftware\Lti1p3\Interfaces\ICache`
+- `BNSoftware\Lti1p3\Interfaces\ICookie`
+- `BNSoftware\Lti1p3\Interfaces\IDatabase`
 
-View the [Laravel Implementation Guide](https://github.com/packbackbooks/lti-1-3-php-library/wiki/Laravel-Implementation-Guide) to see examples (or copy/paste the code outright). Cache and Cookie storage have legacy implementations at `Packback\Lti1p3\ImsStorage\` if you do not wish to implement your own. However, you must implement your own database.
+View the [Laravel Implementation Guide](https://github.com/bnsoftware/lti-1-3-php-library/wiki/Laravel-Implementation-Guide) to see examples (or copy/paste the code outright). Cache and Cookie storage have legacy implementations at `BNSoftware\Lti1p3\ImsStorage\` if you do not wish to implement your own. However, you must implement your own database.
 
 ### Create a JWKS endpoint
 
 A JWKS (JSON Web Key Set) endpoint can be generated for either an individual registration or from an array of `KID`s and private keys.
 
 ```php
-use Packback\Lti1p3\JwksEndpoint;
+use BNSoftware\Lti1p3\JwksEndpoint;
 
 // From issuer
 JwksEndpoint::fromIssuer($database, 'http://example.com')->outputJwks();
@@ -53,7 +52,7 @@ JwksEndpoint::new(['a_unique_KID' => file_get_contents('/path/to/private/key.pem
 
 ## Documentation
 
-[The wiki](https://github.com/packbackbooks/lti-1-3-php-library/wiki) provides more detailed information about how to use this library, including a [Laravel Implementation Guide](https://github.com/packbackbooks/lti-1-3-php-library/wiki/Laravel-Implementation-Guide).
+[The wiki](https://github.com/bnsoftware/lti-1-3-php-library/wiki) provides more detailed information about how to use this library, including a [Laravel Implementation Guide](https://github.com/bnsoftware/lti-1-3-php-library/wiki/Laravel-Implementation-Guide).
 
 ## Contributing
 

--- a/UPGRADES.md
+++ b/UPGRADES.md
@@ -2,7 +2,7 @@
 
 ### Changes to `ICache` methods
 
-Version 5.0 introduced changes to the `Packback\Lti1p3\Interfaces\ICache` interface.
+Version 5.0 introduced changes to the `BNSoftware\Lti1p3\Interfaces\ICache` interface.
 
 * The method `checkNonce()` was renamed to `checkNonceIsValid()`.
 * A second required argument (`$state`) was added to the `cacheNonce()` and `checkNonceIsValid()` methods.
@@ -15,13 +15,13 @@ Stricter typing was added to methods on several interfaces.
 
 ### Stricter typing on `ICache` and `ICookie` methods
 
-Arguments and return types are now strictly typed for methods on the cache and cookie interfaces. Custom implementations of these objects should be updated to adhere to the new typing requirements. View the interface definitions for [`Packback\Lti1p3\Interfaces\ICache`](https://github.com/packbackbooks/lti-1-3-php-library/blob/master/src/Interfaces/ICache.php) and [`Packback\Lti1p3\Interfaces\ICookie`](https://github.com/packbackbooks/lti-1-3-php-library/blob/master/src/Interfaces/ICookie.php) to see specific typing requirements.
+Arguments and return types are now strictly typed for methods on the cache and cookie interfaces. Custom implementations of these objects should be updated to adhere to the new typing requirements. View the interface definitions for [`BNSoftware\Lti1p3\Interfaces\ICache`](https://github.com/packbackbooks/lti-1-3-php-library/blob/master/src/Interfaces/ICache.php) and [`BNSoftware\Lti1p3\Interfaces\ICookie`](https://github.com/packbackbooks/lti-1-3-php-library/blob/master/src/Interfaces/ICookie.php) to see specific typing requirements.
 
 ## 3.0 to 4.0
 
 ### New methods implemented on the `ILtiServiceConnector`
 
-Version 4.0 introduced changes to the `Packback\Lti1p3\Interfaces\ILtiServiceConnector` interface, adding the following methods:
+Version 4.0 introduced changes to the `BNSoftware\Lti1p3\Interfaces\ILtiServiceConnector` interface, adding the following methods:
 
 * `setDebuggingMode()`
 * `makeRequest()`
@@ -31,15 +31,15 @@ Version 4.0 introduced changes to the `Packback\Lti1p3\Interfaces\ILtiServiceCon
 
 ### New method implemented on the `ICache`
 
-Version 3.0 introduced changes to the `Packback\Lti1p3\Interfaces\ICache` interface, adding one method: `clearAccessToken()`. This method must be implemented to any custom implementations of the interface. The [Laravel Implementation Guide](https://github.com/packbackbooks/lti-1-3-php-library/wiki/Laravel-Implementation-Guide#cache) contains an example.
+Version 3.0 introduced changes to the `BNSoftware\Lti1p3\Interfaces\ICache` interface, adding one method: `clearAccessToken()`. This method must be implemented to any custom implementations of the interface. The [Laravel Implementation Guide](https://github.com/packbackbooks/lti-1-3-php-library/wiki/Laravel-Implementation-Guide#cache) contains an example.
 
 ### Using `GuzzleHttp\Client` instead of curl
 
-The `Packback\Lti1p3\LtiServiceConnector` now uses Guzzle instead of curl to make requests. This puts control of this client and its configuration in the hands of the developer. The section below contains information on implementing this change.
+The `BNSoftware\Lti1p3\LtiServiceConnector` now uses Guzzle instead of curl to make requests. This puts control of this client and its configuration in the hands of the developer. The section below contains information on implementing this change.
 
 ### Changes to the `LtiServiceConnector` and LTI services
 
-The implementation of the `Packback\Lti1p3\LtiServiceConnector` changed to act as a general API Client for the various LTI service (Assignment Grades, Names Roles Provisioning, etc.) Specifically, the constructor for the following classes now accept different arguments:
+The implementation of the `BNSoftware\Lti1p3\LtiServiceConnector` changed to act as a general API Client for the various LTI service (Assignment Grades, Names Roles Provisioning, etc.) Specifically, the constructor for the following classes now accept different arguments:
 
 * `LtiAssignmentGradesService`
 * `LtiCourseGroupsService`
@@ -54,7 +54,7 @@ The other LTI services now accept an `ILtiServiceConnector`, `ILtiRegistration`,
 
 ### Renamed Interfaces
 
-A standard naming convention was implemented for interfaces: `Packback\Lti1p3\Interfaces\IObject`. Any implementations of these interfaces should be renamed:
+A standard naming convention was implemented for interfaces: `BNSoftware\Lti1p3\Interfaces\IObject`. Any implementations of these interfaces should be renamed:
 
 * `Cache` to `ICache`
 * `Cookie` to `ICookie`
@@ -65,4 +65,4 @@ A standard naming convention was implemented for interfaces: `Packback\Lti1p3\In
 
 ### New methods implemented on the `ICache`
 
-Version 2.0 introduced changes to the `Packback\Lti1p3\Interfaces\ICache` interface, adding two new methods: `cacheAccessToken()` and `getAccessToken()`. These methods must be implemented to any custom implementations of the interface. The [Laravel Implementation Guide](https://github.com/packbackbooks/lti-1-3-php-library/wiki/Laravel-Implementation-Guide#cache) contains an example.
+Version 2.0 introduced changes to the `BNSoftware\Lti1p3\Interfaces\ICache` interface, adding two new methods: `cacheAccessToken()` and `getAccessToken()`. These methods must be implemented to any custom implementations of the interface. The [Laravel Implementation Guide](https://github.com/packbackbooks/lti-1-3-php-library/wiki/Laravel-Implementation-Guide#cache) contains an example.

--- a/src/Helpers/Helpers.php
+++ b/src/Helpers/Helpers.php
@@ -1,11 +1,12 @@
 <?php
 
-namespace Packback\Lti1p3\Helpers;
+namespace BNSoftware\Lti1p3\Helpers;
 
 class Helpers
 {
     /**
      * @param $value
+     * @return bool
      */
     public static function checkIfNullValue($value): bool
     {

--- a/src/ImsStorage/ImsCache.php
+++ b/src/ImsStorage/ImsCache.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Packback\Lti1p3\ImsStorage;
+namespace BNSoftware\Lti1p3\ImsStorage;
 
-use Packback\Lti1p3\Interfaces\ICache;
+use BNSoftware\Lti1p3\Interfaces\ICache;
 
 class ImsCache implements ICache
 {

--- a/src/ImsStorage/ImsCookie.php
+++ b/src/ImsStorage/ImsCookie.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Packback\Lti1p3\ImsStorage;
+namespace BNSoftware\Lti1p3\ImsStorage;
 
-use Packback\Lti1p3\Interfaces\ICookie;
+use BNSoftware\Lti1p3\Interfaces\ICookie;
 
 class ImsCookie implements ICookie
 {

--- a/src/Interfaces/ICache.php
+++ b/src/Interfaces/ICache.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Packback\Lti1p3\Interfaces;
+namespace BNSoftware\Lti1p3\Interfaces;
 
 interface ICache
 {

--- a/src/Interfaces/ICookie.php
+++ b/src/Interfaces/ICookie.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Packback\Lti1p3\Interfaces;
+namespace BNSoftware\Lti1p3\Interfaces;
 
 interface ICookie
 {

--- a/src/Interfaces/IDatabase.php
+++ b/src/Interfaces/IDatabase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Packback\Lti1p3\Interfaces;
+namespace BNSoftware\Lti1p3\Interfaces;
 
 interface IDatabase
 {

--- a/src/Interfaces/ILtiRegistration.php
+++ b/src/Interfaces/ILtiRegistration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Packback\Lti1p3\Interfaces;
+namespace BNSoftware\Lti1p3\Interfaces;
 
 interface ILtiRegistration
 {

--- a/src/Interfaces/ILtiServiceConnector.php
+++ b/src/Interfaces/ILtiServiceConnector.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Packback\Lti1p3\Interfaces;
+namespace BNSoftware\Lti1p3\Interfaces;
 
 use GuzzleHttp\Psr7\Response;
 

--- a/src/Interfaces/IMessageValidator.php
+++ b/src/Interfaces/IMessageValidator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Packback\Lti1p3\Interfaces;
+namespace BNSoftware\Lti1p3\Interfaces;
 
 interface IMessageValidator
 {

--- a/src/Interfaces/IServiceRequest.php
+++ b/src/Interfaces/IServiceRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Packback\Lti1p3\Interfaces;
+namespace BNSoftware\Lti1p3\Interfaces;
 
 interface IServiceRequest
 {

--- a/src/JwksEndpoint.php
+++ b/src/JwksEndpoint.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Packback\Lti1p3;
+namespace BNSoftware\Lti1p3;
 
 use Firebase\JWT\JWT;
-use Packback\Lti1p3\Interfaces\IDatabase;
-use Packback\Lti1p3\Interfaces\ILtiRegistration;
+use BNSoftware\Lti1p3\Interfaces\IDatabase;
+use BNSoftware\Lti1p3\Interfaces\ILtiRegistration;
 use phpseclib\Crypt\RSA;
 
 class JwksEndpoint

--- a/src/LtiAbstractService.php
+++ b/src/LtiAbstractService.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Packback\Lti1p3;
+namespace BNSoftware\Lti1p3;
 
-use Packback\Lti1p3\Interfaces\ILtiRegistration;
-use Packback\Lti1p3\Interfaces\ILtiServiceConnector;
-use Packback\Lti1p3\Interfaces\IServiceRequest;
+use BNSoftware\Lti1p3\Interfaces\ILtiRegistration;
+use BNSoftware\Lti1p3\Interfaces\ILtiServiceConnector;
+use BNSoftware\Lti1p3\Interfaces\IServiceRequest;
 
 abstract class LtiAbstractService
 {

--- a/src/LtiAssignmentsGradesService.php
+++ b/src/LtiAssignmentsGradesService.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Packback\Lti1p3;
+namespace BNSoftware\Lti1p3;
 
 class LtiAssignmentsGradesService extends LtiAbstractService
 {

--- a/src/LtiConstants.php
+++ b/src/LtiConstants.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Packback\Lti1p3;
+namespace BNSoftware\Lti1p3;
 
 class LtiConstants
 {

--- a/src/LtiCourseGroupsService.php
+++ b/src/LtiCourseGroupsService.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Packback\Lti1p3;
+namespace BNSoftware\Lti1p3;
 
 class LtiCourseGroupsService extends LtiAbstractService
 {

--- a/src/LtiDeepLink.php
+++ b/src/LtiDeepLink.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Packback\Lti1p3;
+namespace BNSoftware\Lti1p3;
 
 use Firebase\JWT\JWT;
-use Packback\Lti1p3\Interfaces\ILtiRegistration;
+use BNSoftware\Lti1p3\Interfaces\ILtiRegistration;
 
 class LtiDeepLink
 {

--- a/src/LtiDeepLinkResource.php
+++ b/src/LtiDeepLinkResource.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Packback\Lti1p3;
+namespace BNSoftware\Lti1p3;
 
 class LtiDeepLinkResource
 {

--- a/src/LtiDeepLinkResourceIcon.php
+++ b/src/LtiDeepLinkResourceIcon.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Packback\Lti1p3;
+namespace BNSoftware\Lti1p3;
 
 class LtiDeepLinkResourceIcon
 {

--- a/src/LtiDeployment.php
+++ b/src/LtiDeployment.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Packback\Lti1p3;
+namespace BNSoftware\Lti1p3;
 
 class LtiDeployment
 {

--- a/src/LtiException.php
+++ b/src/LtiException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Packback\Lti1p3;
+namespace BNSoftware\Lti1p3;
 
 use Exception;
 

--- a/src/LtiGrade.php
+++ b/src/LtiGrade.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Packback\Lti1p3;
+namespace BNSoftware\Lti1p3;
 
 class LtiGrade
 {
@@ -39,7 +39,7 @@ class LtiGrade
             'userId' => $this->user_id,
             'submissionReview' => $this->submission_review,
             'https://canvas.instructure.com/lti/submission' => $this->canvas_extension,
-        ], '\Packback\Lti1p3\Helpers\Helpers::checkIfNullValue');
+        ], '\BNSoftware\Lti1p3\Helpers\Helpers::checkIfNullValue');
 
         return json_encode($request);
     }

--- a/src/LtiGradeSubmissionReview.php
+++ b/src/LtiGradeSubmissionReview.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Packback\Lti1p3;
+namespace BNSoftware\Lti1p3;
 
 class LtiGradeSubmissionReview
 {
@@ -25,7 +25,7 @@ class LtiGradeSubmissionReview
             'label' => $this->label,
             'url' => $this->url,
             'custom' => $this->custom,
-        ], '\Packback\Lti1p3\Helpers\Helpers::checkIfNullValue'));
+        ], '\BNSoftware\Lti1p3\Helpers\Helpers::checkIfNullValue'));
     }
 
     /**

--- a/src/LtiLineitem.php
+++ b/src/LtiLineitem.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Packback\Lti1p3;
+namespace BNSoftware\Lti1p3;
 
 class LtiLineitem
 {
@@ -37,7 +37,7 @@ class LtiLineitem
             'tag' => $this->tag,
             'startDateTime' => $this->start_date_time,
             'endDateTime' => $this->end_date_time,
-        ], '\Packback\Lti1p3\Helpers\Helpers::checkIfNullValue'));
+        ], '\BNSoftware\Lti1p3\Helpers\Helpers::checkIfNullValue'));
     }
 
     /**

--- a/src/LtiMessageLaunch.php
+++ b/src/LtiMessageLaunch.php
@@ -1,19 +1,19 @@
 <?php
 
-namespace Packback\Lti1p3;
+namespace BNSoftware\Lti1p3;
 
 use Firebase\JWT\ExpiredException;
 use Firebase\JWT\JWK;
 use Firebase\JWT\JWT;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\TransferException;
-use Packback\Lti1p3\Interfaces\ICache;
-use Packback\Lti1p3\Interfaces\ICookie;
-use Packback\Lti1p3\Interfaces\IDatabase;
-use Packback\Lti1p3\Interfaces\ILtiServiceConnector;
-use Packback\Lti1p3\MessageValidators\DeepLinkMessageValidator;
-use Packback\Lti1p3\MessageValidators\ResourceMessageValidator;
-use Packback\Lti1p3\MessageValidators\SubmissionReviewMessageValidator;
+use BNSoftware\Lti1p3\Interfaces\ICache;
+use BNSoftware\Lti1p3\Interfaces\ICookie;
+use BNSoftware\Lti1p3\Interfaces\IDatabase;
+use BNSoftware\Lti1p3\Interfaces\ILtiServiceConnector;
+use BNSoftware\Lti1p3\MessageValidators\DeepLinkMessageValidator;
+use BNSoftware\Lti1p3\MessageValidators\ResourceMessageValidator;
+use BNSoftware\Lti1p3\MessageValidators\SubmissionReviewMessageValidator;
 
 class LtiMessageLaunch
 {

--- a/src/LtiNamesRolesProvisioningService.php
+++ b/src/LtiNamesRolesProvisioningService.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Packback\Lti1p3;
+namespace BNSoftware\Lti1p3;
 
 class LtiNamesRolesProvisioningService extends LtiAbstractService
 {

--- a/src/LtiOidcLogin.php
+++ b/src/LtiOidcLogin.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Packback\Lti1p3;
+namespace BNSoftware\Lti1p3;
 
-use Packback\Lti1p3\Interfaces\ICache;
-use Packback\Lti1p3\Interfaces\ICookie;
-use Packback\Lti1p3\Interfaces\IDatabase;
+use BNSoftware\Lti1p3\Interfaces\ICache;
+use BNSoftware\Lti1p3\Interfaces\ICookie;
+use BNSoftware\Lti1p3\Interfaces\IDatabase;
 
 class LtiOidcLogin
 {

--- a/src/LtiRegistration.php
+++ b/src/LtiRegistration.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Packback\Lti1p3;
+namespace BNSoftware\Lti1p3;
 
-use Packback\Lti1p3\Interfaces\ILtiRegistration;
+use BNSoftware\Lti1p3\Interfaces\ILtiRegistration;
 
 class LtiRegistration implements ILtiRegistration
 {

--- a/src/LtiServiceConnector.php
+++ b/src/LtiServiceConnector.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Packback\Lti1p3;
+namespace BNSoftware\Lti1p3;
 
 use Firebase\JWT\JWT;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Psr7\Response;
-use Packback\Lti1p3\Interfaces\ICache;
-use Packback\Lti1p3\Interfaces\ILtiRegistration;
-use Packback\Lti1p3\Interfaces\ILtiServiceConnector;
-use Packback\Lti1p3\Interfaces\IServiceRequest;
+use BNSoftware\Lti1p3\Interfaces\ICache;
+use BNSoftware\Lti1p3\Interfaces\ILtiRegistration;
+use BNSoftware\Lti1p3\Interfaces\ILtiServiceConnector;
+use BNSoftware\Lti1p3\Interfaces\IServiceRequest;
 
 class LtiServiceConnector implements ILtiServiceConnector
 {

--- a/src/MessageValidators/DeepLinkMessageValidator.php
+++ b/src/MessageValidators/DeepLinkMessageValidator.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Packback\Lti1p3\MessageValidators;
+namespace BNSoftware\Lti1p3\MessageValidators;
 
-use Packback\Lti1p3\Interfaces\IMessageValidator;
-use Packback\Lti1p3\LtiConstants;
-use Packback\Lti1p3\LtiException;
+use BNSoftware\Lti1p3\Interfaces\IMessageValidator;
+use BNSoftware\Lti1p3\LtiConstants;
+use BNSoftware\Lti1p3\LtiException;
 
 class DeepLinkMessageValidator implements IMessageValidator
 {

--- a/src/MessageValidators/ResourceMessageValidator.php
+++ b/src/MessageValidators/ResourceMessageValidator.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Packback\Lti1p3\MessageValidators;
+namespace BNSoftware\Lti1p3\MessageValidators;
 
-use Packback\Lti1p3\Interfaces\IMessageValidator;
-use Packback\Lti1p3\LtiConstants;
-use Packback\Lti1p3\LtiException;
+use BNSoftware\Lti1p3\Interfaces\IMessageValidator;
+use BNSoftware\Lti1p3\LtiConstants;
+use BNSoftware\Lti1p3\LtiException;
 
 class ResourceMessageValidator implements IMessageValidator
 {

--- a/src/MessageValidators/SubmissionReviewMessageValidator.php
+++ b/src/MessageValidators/SubmissionReviewMessageValidator.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Packback\Lti1p3\MessageValidators;
+namespace BNSoftware\Lti1p3\MessageValidators;
 
-use Packback\Lti1p3\Interfaces\IMessageValidator;
-use Packback\Lti1p3\LtiConstants;
-use Packback\Lti1p3\LtiException;
+use BNSoftware\Lti1p3\Interfaces\IMessageValidator;
+use BNSoftware\Lti1p3\LtiConstants;
+use BNSoftware\Lti1p3\LtiException;
 
 class SubmissionReviewMessageValidator implements IMessageValidator
 {

--- a/src/OidcException.php
+++ b/src/OidcException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Packback\Lti1p3;
+namespace BNSoftware\Lti1p3;
 
 use Exception;
 

--- a/src/Redirect.php
+++ b/src/Redirect.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Packback\Lti1p3;
+namespace BNSoftware\Lti1p3;
 
-use Packback\Lti1p3\Interfaces\ICookie;
+use BNSoftware\Lti1p3\Interfaces\ICookie;
 
 class Redirect
 {

--- a/src/ServiceRequest.php
+++ b/src/ServiceRequest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Packback\Lti1p3;
+namespace BNSoftware\Lti1p3;
 
-use Packback\Lti1p3\Interfaces\IServiceRequest;
+use BNSoftware\Lti1p3\Interfaces\IServiceRequest;
 
 class ServiceRequest implements IServiceRequest
 {

--- a/tests/Certification/Lti13CertificationTest.php
+++ b/tests/Certification/Lti13CertificationTest.php
@@ -6,17 +6,17 @@ use Carbon\Carbon;
 use Firebase\JWT\JWT;
 use GuzzleHttp\Psr7\Response;
 use Mockery;
-use Packback\Lti1p3\Interfaces\ICache;
-use Packback\Lti1p3\Interfaces\ICookie;
-use Packback\Lti1p3\Interfaces\IDatabase;
-use Packback\Lti1p3\Interfaces\ILtiServiceConnector;
-use Packback\Lti1p3\JwksEndpoint;
-use Packback\Lti1p3\LtiConstants;
-use Packback\Lti1p3\LtiDeployment;
-use Packback\Lti1p3\LtiException;
-use Packback\Lti1p3\LtiMessageLaunch;
-use Packback\Lti1p3\LtiOidcLogin;
-use Packback\Lti1p3\LtiRegistration;
+use BNSoftware\Lti1p3\Interfaces\ICache;
+use BNSoftware\Lti1p3\Interfaces\ICookie;
+use BNSoftware\Lti1p3\Interfaces\IDatabase;
+use BNSoftware\Lti1p3\Interfaces\ILtiServiceConnector;
+use BNSoftware\Lti1p3\JwksEndpoint;
+use BNSoftware\Lti1p3\LtiConstants;
+use BNSoftware\Lti1p3\LtiDeployment;
+use BNSoftware\Lti1p3\LtiException;
+use BNSoftware\Lti1p3\LtiMessageLaunch;
+use BNSoftware\Lti1p3\LtiOidcLogin;
+use BNSoftware\Lti1p3\LtiRegistration;
 use Tests\TestCase;
 
 class TestCache implements ICache

--- a/tests/ImsStorage/ImsCacheTest.php
+++ b/tests/ImsStorage/ImsCacheTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\ImsStorage;
 
-use Packback\Lti1p3\ImsStorage\ImsCache;
+use BNSoftware\Lti1p3\ImsStorage\ImsCache;
 use Tests\TestCase;
 
 class ImsCacheTest extends TestCase

--- a/tests/ImsStorage/ImsCookieTest.php
+++ b/tests/ImsStorage/ImsCookieTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\ImsStorage;
 
-use Packback\Lti1p3\ImsStorage\ImsCookie;
+use BNSoftware\Lti1p3\ImsStorage\ImsCookie;
 use Tests\TestCase;
 
 class ImsCookieTest extends TestCase

--- a/tests/JwksEndpointTest.php
+++ b/tests/JwksEndpointTest.php
@@ -3,9 +3,9 @@
 namespace Tests;
 
 use Mockery;
-use Packback\Lti1p3\Interfaces\IDatabase;
-use Packback\Lti1p3\Interfaces\ILtiRegistration;
-use Packback\Lti1p3\JwksEndpoint;
+use BNSoftware\Lti1p3\Interfaces\IDatabase;
+use BNSoftware\Lti1p3\Interfaces\ILtiRegistration;
+use BNSoftware\Lti1p3\JwksEndpoint;
 
 class JwksEndpointTest extends TestCase
 {

--- a/tests/LtiAssignmentsGradesServiceTest.php
+++ b/tests/LtiAssignmentsGradesServiceTest.php
@@ -3,11 +3,11 @@
 namespace Tests;
 
 use Mockery;
-use Packback\Lti1p3\Interfaces\ILtiRegistration;
-use Packback\Lti1p3\Interfaces\ILtiServiceConnector;
-use Packback\Lti1p3\LtiAssignmentsGradesService;
-use Packback\Lti1p3\LtiConstants;
-use Packback\Lti1p3\LtiLineitem;
+use BNSoftware\Lti1p3\Interfaces\ILtiRegistration;
+use BNSoftware\Lti1p3\Interfaces\ILtiServiceConnector;
+use BNSoftware\Lti1p3\LtiAssignmentsGradesService;
+use BNSoftware\Lti1p3\LtiConstants;
+use BNSoftware\Lti1p3\LtiLineitem;
 
 class LtiAssignmentsGradesServiceTest extends TestCase
 {

--- a/tests/LtiCourseGroupsServiceTest.php
+++ b/tests/LtiCourseGroupsServiceTest.php
@@ -3,9 +3,9 @@
 namespace Tests;
 
 use Mockery;
-use Packback\Lti1p3\Interfaces\ILtiRegistration;
-use Packback\Lti1p3\Interfaces\ILtiServiceConnector;
-use Packback\Lti1p3\LtiCourseGroupsService;
+use BNSoftware\Lti1p3\Interfaces\ILtiRegistration;
+use BNSoftware\Lti1p3\Interfaces\ILtiServiceConnector;
+use BNSoftware\Lti1p3\LtiCourseGroupsService;
 
 class LtiCourseGroupsServiceTest extends TestCase
 {

--- a/tests/LtiDeepLinkResourceIconTest.php
+++ b/tests/LtiDeepLinkResourceIconTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests;
 
-use Packback\Lti1p3\LtiDeepLinkResourceIcon;
+use BNSoftware\Lti1p3\LtiDeepLinkResourceIcon;
 
 class LtiDeepLinkResourceIconTest extends TestCase
 {

--- a/tests/LtiDeepLinkResourceTest.php
+++ b/tests/LtiDeepLinkResourceTest.php
@@ -3,9 +3,9 @@
 namespace Tests;
 
 use Mockery;
-use Packback\Lti1p3\LtiDeepLinkResource;
-use Packback\Lti1p3\LtiDeepLinkResourceIcon;
-use Packback\Lti1p3\LtiLineitem;
+use BNSoftware\Lti1p3\LtiDeepLinkResource;
+use BNSoftware\Lti1p3\LtiDeepLinkResourceIcon;
+use BNSoftware\Lti1p3\LtiLineitem;
 
 class LtiDeepLinkResourceTest extends TestCase
 {

--- a/tests/LtiDeepLinkTest.php
+++ b/tests/LtiDeepLinkTest.php
@@ -3,8 +3,8 @@
 namespace Tests;
 
 use Mockery;
-use Packback\Lti1p3\Interfaces\ILtiRegistration;
-use Packback\Lti1p3\LtiDeepLink;
+use BNSoftware\Lti1p3\Interfaces\ILtiRegistration;
+use BNSoftware\Lti1p3\LtiDeepLink;
 
 class LtiDeepLinkTest extends TestCase
 {

--- a/tests/LtiDeploymentTest.php
+++ b/tests/LtiDeploymentTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests;
 
-use Packback\Lti1p3\LtiDeployment;
+use BNSoftware\Lti1p3\LtiDeployment;
 
 class LtiDeploymentTest extends TestCase
 {

--- a/tests/LtiGradeSubmissionReviewTest.php
+++ b/tests/LtiGradeSubmissionReviewTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests;
 
-use Packback\Lti1p3\LtiGradeSubmissionReview;
+use BNSoftware\Lti1p3\LtiGradeSubmissionReview;
 
 class LtiGradeSubmissionReviewTest extends TestCase
 {

--- a/tests/LtiGradeTest.php
+++ b/tests/LtiGradeTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests;
 
-use Packback\Lti1p3\LtiGrade;
+use BNSoftware\Lti1p3\LtiGrade;
 
 class LtiGradeTest extends TestCase
 {

--- a/tests/LtiLineitemTest.php
+++ b/tests/LtiLineitemTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests;
 
-use Packback\Lti1p3\LtiLineitem;
+use BNSoftware\Lti1p3\LtiLineitem;
 
 class LtiLineitemTest extends TestCase
 {

--- a/tests/LtiMessageLaunchTest.php
+++ b/tests/LtiMessageLaunchTest.php
@@ -6,19 +6,19 @@ use Carbon\Carbon;
 use Firebase\JWT\JWT;
 use GuzzleHttp\Psr7\Response;
 use Mockery;
-use Packback\Lti1p3\Interfaces\ICache;
-use Packback\Lti1p3\Interfaces\ICookie;
-use Packback\Lti1p3\Interfaces\IDatabase;
-use Packback\Lti1p3\Interfaces\ILtiRegistration;
-use Packback\Lti1p3\Interfaces\ILtiServiceConnector;
-use Packback\Lti1p3\JwksEndpoint;
-use Packback\Lti1p3\LtiAssignmentsGradesService;
-use Packback\Lti1p3\LtiConstants;
-use Packback\Lti1p3\LtiCourseGroupsService;
-use Packback\Lti1p3\LtiDeepLink;
-use Packback\Lti1p3\LtiException;
-use Packback\Lti1p3\LtiMessageLaunch;
-use Packback\Lti1p3\LtiNamesRolesProvisioningService;
+use BNSoftware\Lti1p3\Interfaces\ICache;
+use BNSoftware\Lti1p3\Interfaces\ICookie;
+use BNSoftware\Lti1p3\Interfaces\IDatabase;
+use BNSoftware\Lti1p3\Interfaces\ILtiRegistration;
+use BNSoftware\Lti1p3\Interfaces\ILtiServiceConnector;
+use BNSoftware\Lti1p3\JwksEndpoint;
+use BNSoftware\Lti1p3\LtiAssignmentsGradesService;
+use BNSoftware\Lti1p3\LtiConstants;
+use BNSoftware\Lti1p3\LtiCourseGroupsService;
+use BNSoftware\Lti1p3\LtiDeepLink;
+use BNSoftware\Lti1p3\LtiException;
+use BNSoftware\Lti1p3\LtiMessageLaunch;
+use BNSoftware\Lti1p3\LtiNamesRolesProvisioningService;
 
 class LtiMessageLaunchTest extends TestCase
 {

--- a/tests/LtiNamesRolesProvisioningServiceTest.php
+++ b/tests/LtiNamesRolesProvisioningServiceTest.php
@@ -3,9 +3,9 @@
 namespace Tests;
 
 use Mockery;
-use Packback\Lti1p3\Interfaces\ILtiRegistration;
-use Packback\Lti1p3\Interfaces\ILtiServiceConnector;
-use Packback\Lti1p3\LtiNamesRolesProvisioningService;
+use BNSoftware\Lti1p3\Interfaces\ILtiRegistration;
+use BNSoftware\Lti1p3\Interfaces\ILtiServiceConnector;
+use BNSoftware\Lti1p3\LtiNamesRolesProvisioningService;
 
 class LtiNamesRolesProvisioningServiceTest extends TestCase
 {

--- a/tests/LtiOidcLoginTest.php
+++ b/tests/LtiOidcLoginTest.php
@@ -3,12 +3,12 @@
 namespace Tests;
 
 use Mockery;
-use Packback\Lti1p3\Interfaces\ICache;
-use Packback\Lti1p3\Interfaces\ICookie;
-use Packback\Lti1p3\Interfaces\IDatabase;
-use Packback\Lti1p3\LtiMessageLaunch;
-use Packback\Lti1p3\LtiOidcLogin;
-use Packback\Lti1p3\OidcException;
+use BNSoftware\Lti1p3\Interfaces\ICache;
+use BNSoftware\Lti1p3\Interfaces\ICookie;
+use BNSoftware\Lti1p3\Interfaces\IDatabase;
+use BNSoftware\Lti1p3\LtiMessageLaunch;
+use BNSoftware\Lti1p3\LtiOidcLogin;
+use BNSoftware\Lti1p3\OidcException;
 
 class LtiOidcLoginTest extends TestCase
 {

--- a/tests/LtiRegistrationTest.php
+++ b/tests/LtiRegistrationTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests;
 
-use Packback\Lti1p3\LtiRegistration;
+use BNSoftware\Lti1p3\LtiRegistration;
 
 class LtiRegistrationTest extends TestCase
 {

--- a/tests/LtiServiceConnectorTest.php
+++ b/tests/LtiServiceConnectorTest.php
@@ -6,12 +6,12 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Psr7\Response;
 use Mockery;
-use Packback\Lti1p3\Interfaces\ICache;
-use Packback\Lti1p3\Interfaces\ILtiRegistration;
-use Packback\Lti1p3\Interfaces\IServiceRequest;
-use Packback\Lti1p3\LtiRegistration;
-use Packback\Lti1p3\LtiServiceConnector;
-use Packback\Lti1p3\ServiceRequest;
+use BNSoftware\Lti1p3\Interfaces\ICache;
+use BNSoftware\Lti1p3\Interfaces\ILtiRegistration;
+use BNSoftware\Lti1p3\Interfaces\IServiceRequest;
+use BNSoftware\Lti1p3\LtiRegistration;
+use BNSoftware\Lti1p3\LtiServiceConnector;
+use BNSoftware\Lti1p3\ServiceRequest;
 use Psr\Http\Message\StreamInterface;
 
 class LtiServiceConnectorTest extends TestCase

--- a/tests/MessageValidators/DeepLinkMessageValidatorTest.php
+++ b/tests/MessageValidators/DeepLinkMessageValidatorTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\MessageValidators;
 
-use Packback\Lti1p3\MessageValidators\DeepLinkMessageValidator;
+use BNSoftware\Lti1p3\MessageValidators\DeepLinkMessageValidator;
 use Tests\TestCase;
 
 class DeepLinkMessageValidatorTest extends TestCase

--- a/tests/MessageValidators/ResourceMessageValidatorTest.php
+++ b/tests/MessageValidators/ResourceMessageValidatorTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\MessageValidators;
 
-use Packback\Lti1p3\MessageValidators\ResourceMessageValidator;
+use BNSoftware\Lti1p3\MessageValidators\ResourceMessageValidator;
 use Tests\TestCase;
 
 class ResourceMessageValidatorTest extends TestCase

--- a/tests/MessageValidators/SubmissionReviewMessageValidatorTest.php
+++ b/tests/MessageValidators/SubmissionReviewMessageValidatorTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\MessageValidators;
 
-use Packback\Lti1p3\MessageValidators\SubmissionReviewMessageValidator;
+use BNSoftware\Lti1p3\MessageValidators\SubmissionReviewMessageValidator;
 use Tests\TestCase;
 
 class SubmissionReviewMessageValidatorTest extends TestCase

--- a/tests/RedirectTest.php
+++ b/tests/RedirectTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests;
 
-use Packback\Lti1p3\Redirect;
+use BNSoftware\Lti1p3\Redirect;
 
 class RedirectTest extends TestCase
 {


### PR DESCRIPTION
## Summary of Changes

This first commit updates the namespace used in the library as well as the README to indicate the library was forked from `packbackbooks/lti-1-3-library`

## Testing

N/A

- [ ] I have added automated tests for my changes
- [ ] I ran `composer test` before opening this PR
- [ ] I ran `composer lint-fix` before opening this PR
