### PR TITLE
Use a matrix to test php versions

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -23,9 +23,6 @@ jobs:
         php:
           - "7.4"
           - "8.1"
-        dependencies:
-          - "lowest"
-          - "highest"
     steps:
       - uses: "actions/checkout@v3"
       - uses: "shivammathur/setup-php@v2"

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -18,19 +18,22 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php:
+          - "5.6"
+          - "8.1"
+        dependencies:
+          - "lowest"
+          - "highest"
     steps:
-      - uses: actions/checkout@v3
+      - uses: "actions/checkout@v3"
+      - uses: "shivammathur/setup-php@v2"
+        with:
+          php-version: "${{ matrix.php }}"
       - uses: "ramsey/composer-install@v2"
+        with:
+          dependency-versions: "${{ matrix.dependencies }}"
+          composer-options: "${{ matrix.composer-options }}"
       - name: Run tests
         run: composer test
-
-  # test-php-latest:
-  #   name: Test in PHP 5.6
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: "shivammathur/setup-php@v2"
-  #       with:
-  #         php-version: "latest"
-  #     - uses: "ramsey/composer-install@v2"
-  #     - name: Run tests
-  #       run: composer test

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         php:
           - "7.4"
-          - "8.1"
+          - "latest"
     steps:
       - uses: "actions/checkout@v3"
       - uses: "shivammathur/setup-php@v2"

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         php:
-          - "7.2"
+          - "7.4"
           - "8.1"
         dependencies:
           - "lowest"

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -15,24 +15,24 @@ jobs:
       - name: Check style
         run: composer lint
 
-  test-php56:
-    name: Test in PHP 5.6
-    steps:
-      - uses: actions/checkout@v3
-      - uses: "shivammathur/setup-php@v2"
-        with:
-          php-version: "5.6"
-      - uses: "ramsey/composer-install@v2"
-      - name: Run tests
-        run: composer test
+  # test-php56:
+  #   name: Test in PHP 5.6
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: "shivammathur/setup-php@v2"
+  #       with:
+  #         php-version: "5.6"
+  #     - uses: "ramsey/composer-install@v2"
+  #     - name: Run tests
+  #       run: composer test
 
-  test-php-latest:
-    name: Test in PHP 5.6
-    steps:
-      - uses: actions/checkout@v3
-      - uses: "shivammathur/setup-php@v2"
-        with:
-          php-version: "latest"
-      - uses: "ramsey/composer-install@v2"
-      - name: Run tests
-        run: composer test
+  # test-php-latest:
+  #   name: Test in PHP 5.6
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: "shivammathur/setup-php@v2"
+  #       with:
+  #         php-version: "latest"
+  #     - uses: "ramsey/composer-install@v2"
+  #     - name: Run tests
+  #       run: composer test

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -9,7 +9,7 @@ jobs:
   run-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Install Composer Dependencies
         run: |
           composer install -q --no-ansi --no-interaction --no-scripts --no-suggest \
@@ -18,3 +18,23 @@ jobs:
         run: composer test
       - name: Check style
         run: composer lint
+
+  build:
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: [ ubuntu-latest ]
+        php: [ '5.6', '8.1' ]
+    name: PHP ${{ matrix.php }} sample
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup PHP
+        uses: nanasess/setup-php@v3
+        with:
+          php-version: ${{ matrix.php }}
+      - name: Install Composer Dependencies
+        run: |
+          composer install -q --no-ansi --no-interaction --no-scripts --no-suggest \
+            --no-progress --prefer-dist
+      - name: Run tests
+        run: composer test

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         php:
-          - "5.6"
+          - "7.2"
           - "8.1"
         dependencies:
           - "lowest"

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - master
 jobs:
-  - lint:
+  lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
@@ -15,8 +15,9 @@ jobs:
       - name: Check style
         run: composer lint
 
-  - test-php:
+  test:
     name: Test
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: "ramsey/composer-install@v2"

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -7,7 +7,7 @@ on:
       - master
 jobs:
   lint:
-    name: Linting
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -15,16 +15,13 @@ jobs:
       - name: Check style
         run: composer lint
 
-  # test-php56:
-  #   name: Test in PHP 5.6
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: "shivammathur/setup-php@v2"
-  #       with:
-  #         php-version: "5.6"
-  #     - uses: "ramsey/composer-install@v2"
-  #     - name: Run tests
-  #       run: composer test
+  test-php:
+    name: Test
+    steps:
+      - uses: actions/checkout@v3
+      - uses: "ramsey/composer-install@v2"
+      - name: Run tests
+        run: composer test
 
   # test-php-latest:
   #   name: Test in PHP 5.6

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - master
 jobs:
-  lint:
+  - lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
@@ -15,7 +15,7 @@ jobs:
       - name: Check style
         run: composer lint
 
-  test-php:
+  - test-php:
     name: Test
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -6,35 +6,33 @@ on:
     branches:
       - master
 jobs:
-  run-tests:
+  lint:
+    name: Linting
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install Composer Dependencies
-        run: |
-          composer install -q --no-ansi --no-interaction --no-scripts --no-suggest \
-            --no-progress --prefer-dist
-      - name: Run tests
-        run: composer test
+      - uses: "ramsey/composer-install@v2"
       - name: Check style
         run: composer lint
 
-  build:
-    runs-on: ${{ matrix.operating-system }}
-    strategy:
-      matrix:
-        operating-system: [ ubuntu-latest ]
-        php: [ '5.6', '8.1' ]
-    name: PHP ${{ matrix.php }} sample
+  test-php56:
+    name: Test in PHP 5.6
     steps:
       - uses: actions/checkout@v3
-      - name: Setup PHP
-        uses: nanasess/setup-php@v3
+      - uses: "shivammathur/setup-php@v2"
         with:
-          php-version: ${{ matrix.php }}
-      - name: Install Composer Dependencies
-        run: |
-          composer install -q --no-ansi --no-interaction --no-scripts --no-suggest \
-            --no-progress --prefer-dist
+          php-version: "5.6"
+      - uses: "ramsey/composer-install@v2"
+      - name: Run tests
+        run: composer test
+
+  test-php-latest:
+    name: Test in PHP 5.6
+    steps:
+      - uses: actions/checkout@v3
+      - uses: "shivammathur/setup-php@v2"
+        with:
+          php-version: "latest"
+      - uses: "ramsey/composer-install@v2"
       - name: Run tests
         run: composer test


### PR DESCRIPTION
## Summary of Changes

This adds testing for our minimum php version (7.4) and the latest. This ensures we don't break something by adding php8-specific syntax.

## Testing

<!-- Describe how this PR has been tested, manually and automatically. -->

- [x] I have added automated tests for my changes
- [x] I ran `composer test` before opening this PR
- [x] I ran `composer lint-fix` before opening this PR
