### PR TITLE
Mark internal interfaces as such

### DIFF
--- a/src/Interfaces/ILtiRegistration.php
+++ b/src/Interfaces/ILtiRegistration.php
@@ -2,6 +2,7 @@
 
 namespace Packback\Lti1p3\Interfaces;
 
+/** @internal */
 interface ILtiRegistration
 {
     public function getIssuer();

--- a/src/Interfaces/IMessageValidator.php
+++ b/src/Interfaces/IMessageValidator.php
@@ -2,6 +2,7 @@
 
 namespace Packback\Lti1p3\Interfaces;
 
+/** @internal */
 interface IMessageValidator
 {
     public static function getMessageType(): string;

--- a/src/Interfaces/IServiceRequest.php
+++ b/src/Interfaces/IServiceRequest.php
@@ -2,6 +2,7 @@
 
 namespace Packback\Lti1p3\Interfaces;
 
+/** @internal */
 interface IServiceRequest
 {
     public function getMethod(): string;


### PR DESCRIPTION
## Summary of Changes

Per the feedback in https://github.com/packbackbooks/lti-1-3-php-library/issues/77, I've marked internal interfaces as such so that people don't try to implement them themselves. As the issue author indicated, there was no indication that these interfaces are only for internal use and shouldn't be used externally.

## Testing

<!-- Describe how this PR has been tested, manually and automatically. -->

- [x] I have added automated tests for my changes
- [x] I ran `composer test` before opening this PR
- [x] I ran `composer lint-fix` before opening this PR
