### PR TITLE
Fixed dynamic properties deprecation in PHP 8.2

### DIFF
--- a/src/LtiGrade.php
+++ b/src/LtiGrade.php
@@ -12,6 +12,7 @@ class LtiGrade
     private $timestamp;
     private $user_id;
     private $submission_review;
+    private $canvas_extension;
 
     public function __construct(array $grade = null)
     {


### PR DESCRIPTION
## Summary of Changes

PHP 8.2 will deprecate dynamic properties, so to avoid it, I added a class property.

## Testing

I'm using PHPStan to scan all classes with a warning "Access to an undefined property..." after I added the missing property in the class, the warning is gone.
