### PR TITLE
Use default arg separator for http_build_query in login

### DIFF
--- a/src/LtiOidcLogin.php
+++ b/src/LtiOidcLogin.php
@@ -93,10 +93,10 @@ class LtiOidcLogin
             $auth_params['lti_message_hint'] = $request['lti_message_hint'];
         }
 
-        $auth_login_return_url = $registration->getAuthLoginUrl().'?'.http_build_query($auth_params);
+        $auth_login_return_url = $registration->getAuthLoginUrl().'?'.http_build_query($auth_params, '', '&');
 
         // Return auth redirect.
-        return new Redirect($auth_login_return_url, http_build_query($request));
+        return new Redirect($auth_login_return_url, http_build_query($request, '', '&'));
     }
 
     public function validateOidcLogin($request)


### PR DESCRIPTION
This allows login to function in applications which override the default value of PHP's arg_separator.output.

## Summary of Changes

In these usages of http_build_query, we always want '&', otherwise the query breaks. For applications that use code like:
`ini_set('arg_separator.output', '&amp;');`
elsewhere, this will cause issues.

## Testing

<!-- Describe how this PR has been tested, manually and automatically. -->

- [ ] I have added automated tests for my changes
- [x] I ran `composer test` before opening this PR
- [x] I ran `composer lint-fix` before opening this PR
