### PR TITLE
PODC-414: Add a "Delete Lineitem" Method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 5.2.7
+## 5.3.0
 
 Add `AssignmentGradesService::deleteLineitem()` to update a line item [#83](https://github.com/packbackbooks/lti-1-3-php-library/pull/83).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.2.7
+
+Add `AssignmentGradesService::deleteLineitem()` to update a line item [#83](https://github.com/packbackbooks/lti-1-3-php-library/pull/83).
+
 ## 5.1.7
 
 Add `AssignmentGradesService::updateLineitem()` to update a line item [#58](https://github.com/packbackbooks/lti-1-3-php-library/pull/58).

--- a/src/LtiAssignmentsGradesService.php
+++ b/src/LtiAssignmentsGradesService.php
@@ -98,6 +98,17 @@ class LtiAssignmentsGradesService extends LtiAbstractService
         return new LtiLineitem($createdLineItem['body']);
     }
 
+    public function deleteLineitem(): array
+    {
+        $request = new ServiceRequest(
+            ServiceRequest::METHOD_DELETE,
+            $this->getServiceData()['lineitem'],
+            ServiceRequest::TYPE_DELETE_LINEITEM
+        );
+
+        return $this->makeServiceRequest($request);
+    }
+
     public function findOrCreateLineitem(LtiLineitem $newLineItem): LtiLineitem
     {
         return $this->findLineItem($newLineItem) ?? $this->createLineitem($newLineItem);

--- a/src/ServiceRequest.php
+++ b/src/ServiceRequest.php
@@ -7,6 +7,7 @@ use Packback\Lti1p3\Interfaces\IServiceRequest;
 class ServiceRequest implements IServiceRequest
 {
     // Request methods
+    public const METHOD_DELETE = 'DELETE';
     public const METHOD_GET = 'GET';
     public const METHOD_POST = 'POST';
     public const METHOD_PUT = 'PUT';
@@ -20,6 +21,7 @@ class ServiceRequest implements IServiceRequest
     public const TYPE_GET_GRADES = 'get_grades';
     public const TYPE_SYNC_GRADE = 'sync_grades';
     public const TYPE_CREATE_LINEITEM = 'create_lineitem';
+    public const TYPE_DELETE_LINEITEM = 'delete_lineitem';
     public const TYPE_GET_LINEITEMS = 'get_lineitems';
     public const TYPE_GET_LINEITEM = 'get_lineitem';
     public const TYPE_UPDATE_LINEITEM = 'update_lineitem';
@@ -125,6 +127,7 @@ class ServiceRequest implements IServiceRequest
             static::TYPE_GET_GRADES => 'Getting grades:',
             static::TYPE_SYNC_GRADE => 'Syncing grade for this lti_user_id:',
             static::TYPE_CREATE_LINEITEM => 'Creating lineitem:',
+            static::TYPE_DELETE_LINEITEM => 'Deleting lineitem:',
             static::TYPE_GET_LINEITEMS => 'Getting lineitems:',
             static::TYPE_GET_LINEITEM => 'Getting a lineitem:',
             static::TYPE_UPDATE_LINEITEM => 'Updating lineitem:',

--- a/tests/LtiAssignmentsGradesServiceTest.php
+++ b/tests/LtiAssignmentsGradesServiceTest.php
@@ -69,6 +69,6 @@ class LtiAssignmentsGradesServiceTest extends TestCase
 
         $result = $service->deleteLineitem();
 
-        $this->assertEquals($result, $result);
+        $this->assertEquals($response, $result);
     }
 }

--- a/tests/LtiAssignmentsGradesServiceTest.php
+++ b/tests/LtiAssignmentsGradesServiceTest.php
@@ -50,7 +50,25 @@ class LtiAssignmentsGradesServiceTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
-    /*
-     * @todo Test this
-     */
+    public function testItDeletesALineItem()
+    {
+        $serviceData = [
+            'scope' => [LtiConstants::AGS_SCOPE_LINEITEM],
+            'lineitem' => 'https://canvas.localhost/api/lti/courses/8/line_items/27',
+        ];
+
+        $service = new LtiAssignmentsGradesService($this->connector, $this->registration, $serviceData);
+
+        $response = [
+            'status' => 204,
+            'body' => null,
+        ];
+
+        $this->connector->shouldReceive('makeServiceRequest')
+            ->once()->andReturn($response);
+
+        $result = $service->deleteLineitem();
+
+        $this->assertEquals($result, $result);
+    }
 }


### PR DESCRIPTION
## Summary of Changes

This PR adds a `AssignmentGradesService::deleteLineItem` method to be used by LTI tools trying to proactively manage LMS columns.

## Testing

This PR has been tested manually in related feature-work by deleting a line item via the new method on a local developer instance of Canvas. See https://github.com/packbackbooks/questions/pull/7933.

- [ ] I have added automated tests for my changes
- [x] I ran `composer test` before opening this PR
- [x] I ran `composer lint-fix` before opening this PR
