### PR TITLE
Validate scopes before a request

### DIFF
--- a/src/LtiAbstractService.php
+++ b/src/LtiAbstractService.php
@@ -36,6 +36,13 @@ abstract class LtiAbstractService
 
     abstract public function getScope(): array;
 
+    protected function validateScopes(array $scopes): void
+    {
+        if (empty(array_intersect($scopes, $this->getScope()))) {
+            throw new LtiException('Missing required scope', 1);
+        }
+    }
+
     protected function makeServiceRequest(IServiceRequest $request): array
     {
         return $this->serviceConnector->makeServiceRequest(

--- a/src/LtiAssignmentsGradesService.php
+++ b/src/LtiAssignmentsGradesService.php
@@ -30,9 +30,7 @@ class LtiAssignmentsGradesService extends LtiAbstractService
 
     public function putGrade(LtiGrade $grade, LtiLineitem $lineitem = null)
     {
-        if (!in_array(LtiConstants::AGS_SCOPE_SCORE, $this->getScope())) {
-            throw new LtiException('Missing required scope', 1);
-        }
+        $this->validateScopes([LtiConstants::AGS_SCOPE_SCORE]);
 
         $lineitem = $this->ensureLineItemExists($lineitem);
 
@@ -136,9 +134,7 @@ class LtiAssignmentsGradesService extends LtiAbstractService
 
     public function getLineItems(): array
     {
-        if (!in_array(LtiConstants::AGS_SCOPE_LINEITEM, $this->getScope())) {
-            throw new LtiException('Missing required scope', 1);
-        }
+        $this->validateScopes([LtiConstants::AGS_SCOPE_LINEITEM, LtiConstants::AGS_SCOPE_LINEITEM_READONLY]);
 
         $request = new ServiceRequest(
             ServiceRequest::METHOD_GET,
@@ -159,9 +155,7 @@ class LtiAssignmentsGradesService extends LtiAbstractService
 
     public function getLineItem(string $url): LtiLineitem
     {
-        if (!in_array(LtiConstants::AGS_SCOPE_LINEITEM, $this->getScope())) {
-            throw new LtiException('Missing required scope', 1);
-        }
+        $this->validateScopes([LtiConstants::AGS_SCOPE_LINEITEM, LtiConstants::AGS_SCOPE_LINEITEM_READONLY]);
 
         $request = new ServiceRequest(
             ServiceRequest::METHOD_GET,

--- a/tests/LtiAssignmentsGradesServiceTest.php
+++ b/tests/LtiAssignmentsGradesServiceTest.php
@@ -50,6 +50,32 @@ class LtiAssignmentsGradesServiceTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
+    public function testItGetsSingleLineItemWithReadonlyScope()
+    {
+        $ltiLineitemData = [
+            'id' => 'testId',
+        ];
+
+        $serviceData = [
+            'scope' => [LtiConstants::AGS_SCOPE_LINEITEM_READONLY],
+        ];
+
+        $service = new LtiAssignmentsGradesService($this->connector, $this->registration, $serviceData);
+
+        $response = [
+            'body' => $ltiLineitemData,
+        ];
+
+        $this->connector->shouldReceive('makeServiceRequest')
+            ->once()->andReturn($response);
+
+        $expected = new LtiLineitem($ltiLineitemData);
+
+        $result = $service->getLineItem('someUrl');
+
+        $this->assertEquals($expected, $result);
+    }
+
     public function testItDeletesALineItem()
     {
         $serviceData = [


### PR DESCRIPTION
## Summary of Changes

This PR adds a method for validating that a service request has valid scopes. It also adds two missing scopes to the AGS, which was highlighted in https://github.com/packbackbooks/lti-1-3-php-library/pull/85.

## Testing

<!-- Describe how this PR has been tested, manually and automatically. -->

- [x] I have added automated tests for my changes
- [x] I ran `composer test` before opening this PR
- [x] I ran `composer lint-fix` before opening this PR
