### PR TITLE
PODA-966: Fix updating a line item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 5.3.2
+
+Fix URL for updating a line item [#87](https://github.com/packbackbooks/lti-1-3-php-library/pull/87).
+
 ## 5.3.1
 
-Fix URL for updating a line item [#87](https://github.com/packbackbooks/lti-1-3-php-library/pull/87).s
+Validate scopes before a request [#86](https://github.com/packbackbooks/lti-1-3-php-library/pull/86).
 
 ## 5.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.3.1
+
+Fix URL for updating a line item [#87](https://github.com/packbackbooks/lti-1-3-php-library/pull/87).s
+
 ## 5.3.0
 
 Add `AssignmentGradesService::deleteLineitem()` to update a line item [#83](https://github.com/packbackbooks/lti-1-3-php-library/pull/83).

--- a/src/LtiAssignmentsGradesService.php
+++ b/src/LtiAssignmentsGradesService.php
@@ -68,7 +68,7 @@ class LtiAssignmentsGradesService extends LtiAbstractService
     {
         $request = new ServiceRequest(
             ServiceRequest::METHOD_PUT,
-            $this->getServiceData()['lineitems'],
+            $this->getServiceData()['lineitem'],
             ServiceRequest::TYPE_UPDATE_LINEITEM
         );
 


### PR DESCRIPTION
## Summary of Changes

This PR fixes the URL for updating an individual line item.

## Testing

I manually verified that these changes allow line items to be updated in Canvas.

- [ ] I have added automated tests for my changes
- [X] I ran `composer test` before opening this PR
- [X] I ran `composer lint-fix` before opening this PR
