### PR TITLE
PODA-966: Fix changelog URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 5.3.2
 
-Fix URL for updating a line item [#87](https://github.com/packbackbooks/lti-1-3-php-library/pull/87).
+Fix URL for updating a line item [#89](https://github.com/packbackbooks/lti-1-3-php-library/pull/89).
 
 ## 5.3.1
 


### PR DESCRIPTION
## Summary of Changes

The URL for the PR in the changelog was incorrect; rather than double-checking after creating the PR, I wrongly assumed that there wouldn't be any other PRs since the last one released.

## Testing

- [ ] I have added automated tests for my changes
- [X] I ran `composer test` before opening this PR
- [X] I ran `composer lint-fix` before opening this PR
