### PR TITLE
ONCALL-718: Differentiate error messaging for public key

### DIFF
--- a/src/LtiMessageLaunch.php
+++ b/src/LtiMessageLaunch.php
@@ -126,6 +126,10 @@ class LtiMessageLaunch
         return $new->validateRegistration();
     }
 
+    /**
+     * Toggles the debugging mode of the service connector. This is useful for
+     * getting logs of requests for the public key.
+     */
     public function setServiceConnectorDebuggingMode(bool $debuggingMode): void
     {
         if ($this->serviceConnector) {

--- a/src/LtiMessageLaunch.php
+++ b/src/LtiMessageLaunch.php
@@ -79,8 +79,7 @@ class LtiMessageLaunch
         IDatabase $database,
         ICache $cache = null,
         ICookie $cookie = null,
-        ILtiServiceConnector $serviceConnector = null,
-        bool $serviceConnectorDebuggingMode = false
+        ILtiServiceConnector $serviceConnector = null
     ) {
         $this->db = $database;
 
@@ -89,10 +88,6 @@ class LtiMessageLaunch
         $this->cache = $cache;
         $this->cookie = $cookie;
         $this->serviceConnector = $serviceConnector;
-
-        if ($this->serviceConnector && $serviceConnectorDebuggingMode) {
-            $this->serviceConnector->setDebuggingMode($serviceConnectorDebuggingMode);
-        }
     }
 
     /**
@@ -102,16 +97,9 @@ class LtiMessageLaunch
         IDatabase $database,
         ICache $cache = null,
         ICookie $cookie = null,
-        ILtiServiceConnector $serviceConnector = null,
-        bool $serviceConnectorDebuggingMode = false
+        ILtiServiceConnector $serviceConnector = null
     ) {
-        return new LtiMessageLaunch(
-            $database,
-            $cache,
-            $cookie,
-            $serviceConnector,
-            $serviceConnectorDebuggingMode
-        );
+        return new LtiMessageLaunch($database, $cache, $cookie, $serviceConnector);
     }
 
     /**
@@ -129,20 +117,20 @@ class LtiMessageLaunch
         $launch_id,
         IDatabase $database,
         ICache $cache = null,
-        ILtiServiceConnector $serviceConnector = null,
-        bool $serviceConnectorDebuggingMode = false
+        ILtiServiceConnector $serviceConnector = null
     ) {
-        $new = new LtiMessageLaunch(
-            $database,
-            $cache,
-            null,
-            $serviceConnector,
-            $serviceConnectorDebuggingMode
-        );
+        $new = new LtiMessageLaunch($database, $cache, null, $serviceConnector);
         $new->launch_id = $launch_id;
         $new->jwt = ['body' => $new->cache->getLaunchData($launch_id)];
 
         return $new->validateRegistration();
+    }
+
+    public function setServiceConnectorDebuggingMode(bool $debuggingMode): void
+    {
+        if ($this->serviceConnector) {
+            $this->serviceConnector->setDebuggingMode($debuggingMode);
+        }
     }
 
     /**

--- a/src/LtiMessageLaunch.php
+++ b/src/LtiMessageLaunch.php
@@ -127,17 +127,6 @@ class LtiMessageLaunch
     }
 
     /**
-     * Toggles the debugging mode of the service connector. This is useful for
-     * getting logs of requests for the public key.
-     */
-    public function setServiceConnectorDebuggingMode(bool $debuggingMode): void
-    {
-        if ($this->serviceConnector) {
-            $this->serviceConnector->setDebuggingMode($debuggingMode);
-        }
-    }
-
-    /**
      * Validates all aspects of an incoming LTI message launch and caches the launch if successful.
      *
      * @param array|string $request An array of post request parameters. If not set will default to $_POST.

--- a/src/LtiMessageLaunch.php
+++ b/src/LtiMessageLaunch.php
@@ -79,7 +79,8 @@ class LtiMessageLaunch
         IDatabase $database,
         ICache $cache = null,
         ICookie $cookie = null,
-        ILtiServiceConnector $serviceConnector = null
+        ILtiServiceConnector $serviceConnector = null,
+        bool $serviceConnectorDebuggingMode = false
     ) {
         $this->db = $database;
 
@@ -88,6 +89,10 @@ class LtiMessageLaunch
         $this->cache = $cache;
         $this->cookie = $cookie;
         $this->serviceConnector = $serviceConnector;
+
+        if ($this->serviceConnector) {
+            $this->serviceConnector->setDebuggingMode($serviceConnectorDebuggingMode);
+        }
     }
 
     /**
@@ -97,9 +102,16 @@ class LtiMessageLaunch
         IDatabase $database,
         ICache $cache = null,
         ICookie $cookie = null,
-        ILtiServiceConnector $serviceConnector = null
+        ILtiServiceConnector $serviceConnector = null,
+        bool $serviceConnectorDebuggingMode = false
     ) {
-        return new LtiMessageLaunch($database, $cache, $cookie, $serviceConnector);
+        return new LtiMessageLaunch(
+            $database,
+            $cache,
+            $cookie,
+            $serviceConnector,
+            $serviceConnectorDebuggingMode
+        );
     }
 
     /**
@@ -117,9 +129,16 @@ class LtiMessageLaunch
         $launch_id,
         IDatabase $database,
         ICache $cache = null,
-        ILtiServiceConnector $serviceConnector = null
+        ILtiServiceConnector $serviceConnector = null,
+        bool $serviceConnectorDebuggingMode = false
     ) {
-        $new = new LtiMessageLaunch($database, $cache, null, $serviceConnector);
+        $new = new LtiMessageLaunch(
+            $database,
+            $cache,
+            null,
+            $serviceConnector,
+            $serviceConnectorDebuggingMode
+        );
         $new->launch_id = $launch_id;
         $new->jwt = ['body' => $new->cache->getLaunchData($launch_id)];
 

--- a/src/LtiMessageLaunch.php
+++ b/src/LtiMessageLaunch.php
@@ -6,7 +6,6 @@ use Exception;
 use Firebase\JWT\ExpiredException;
 use Firebase\JWT\JWK;
 use Firebase\JWT\JWT;
-use GuzzleHttp\Client;
 use GuzzleHttp\Exception\TransferException;
 use Packback\Lti1p3\Interfaces\ICache;
 use Packback\Lti1p3\Interfaces\ICookie;
@@ -24,6 +23,7 @@ class LtiMessageLaunch
 
     public const ERR_FETCH_PUBLIC_KEY = 'Failed to fetch public key.';
     public const ERR_NO_PUBLIC_KEY = 'Unable to find public key.';
+    public const ERR_NO_MATCHING_PUBLIC_KEY = 'Unable to find a public key which matches your JWT.';
     public const ERR_STATE_NOT_FOUND = 'Please make sure you have cookies enabled in this browser and that you are not in private or incognito mode';
     public const ERR_MISSING_ID_TOKEN = 'Missing id_token.';
     public const ERR_INVALID_ID_TOKEN = 'Invalid id_token, JWT must contain 3 parts';
@@ -342,7 +342,7 @@ class LtiMessageLaunch
         }
 
         // Could not find public key with a matching kid and alg.
-        throw new LtiException(static::ERR_NO_PUBLIC_KEY);
+        throw new LtiException(static::ERR_NO_MATCHING_PUBLIC_KEY);
     }
 
     /**

--- a/src/LtiMessageLaunch.php
+++ b/src/LtiMessageLaunch.php
@@ -90,7 +90,7 @@ class LtiMessageLaunch
         $this->cookie = $cookie;
         $this->serviceConnector = $serviceConnector;
 
-        if ($this->serviceConnector) {
+        if ($this->serviceConnector && $serviceConnectorDebuggingMode) {
             $this->serviceConnector->setDebuggingMode($serviceConnectorDebuggingMode);
         }
     }

--- a/tests/Certification/Lti13CertificationTest.php
+++ b/tests/Certification/Lti13CertificationTest.php
@@ -79,7 +79,7 @@ class TestCookie implements ICookie
 class TestDb implements IDatabase
 {
     private $registrations = [];
-    private $deplomyments = [];
+    private $deployments = [];
 
     public function __construct($registration, $deployment)
     {
@@ -462,15 +462,6 @@ class Lti13CertificationTest extends TestCase
         }
         echo PHP_EOL;
         $this->assertEquals($casesCount, $testedCases);
-    }
-
-    private function login($loginData = null)
-    {
-        $loginData = $loginData ?? [
-            'iss' => $this->issuer['issuer'],
-            'login_hint' => '535fa085f22b4655f48cd5a36a9215f64c062838',
-        ];
-        $loginData['client_id'] = $this->issuer['client_id'];
     }
 
     private function launch($payload)


### PR DESCRIPTION
## Summary of Changes

This PR adds a different error messages to differentiate between failing to find a public key (when the request to get the key set fails) vs when there isn't a public key matching the JWT. This is to clarify exactly what is causing the error `Unable to find public key.`, which was previously being thrown in two places.

## Testing

I copy+pasted my changes to the backend vendor code and verified that, by forcing that exception to be thrown, the error is displayed as expected. I also verified that debugging can be toggled on the service connector by passing `true` in for the last parameter.

- [ ] I have added automated tests for my changes
- [X] I ran `composer test` before opening this PR
- [X] I ran `composer lint-fix` before opening this PR
