### PR TITLE
Support multiple pages in getGrades()

### DIFF
--- a/src/LtiAssignmentsGradesService.php
+++ b/src/LtiAssignmentsGradesService.php
@@ -127,9 +127,9 @@ class LtiAssignmentsGradesService extends LtiAbstractService
             ServiceRequest::TYPE_GET_GRADES
         );
         $request->setAccept(static::CONTENTTYPE_RESULTCONTAINER);
-        $scores = $this->makeServiceRequest($request);
+        $scores = $this->getAll($request);
 
-        return $scores['body'];
+        return $scores;
     }
 
     public function getLineItems(): array

--- a/src/LtiDeepLinkDateTimeInterval.php
+++ b/src/LtiDeepLinkDateTimeInterval.php
@@ -9,7 +9,7 @@ class LtiDeepLinkDateTimeInterval
     private ?DateTime $start;
     private ?DateTime $end;
 
-    public function __construct(?DateTime $start = null, ?DateTime $end = null)
+    public function __construct(DateTime $start = null, DateTime $end = null)
     {
         if ($start !== null && $end !== null && $end < $start) {
             throw new LtiException('Interval start time cannot be greater than end time');

--- a/src/LtiDeepLinkResourceIframe.php
+++ b/src/LtiDeepLinkResourceIframe.php
@@ -7,7 +7,7 @@ class LtiDeepLinkResourceIframe
     private ?int $width;
     private ?int $height;
 
-    public function __construct(?int $width = null, ?int $height = null)
+    public function __construct(int $width = null, int $height = null)
     {
         $this->width = $width ?? null;
         $this->height = $height ?? null;

--- a/src/LtiDeepLinkResourceWindow.php
+++ b/src/LtiDeepLinkResourceWindow.php
@@ -9,7 +9,7 @@ class LtiDeepLinkResourceWindow
     private ?int $height;
     private ?string $window_features;
 
-    public function __construct(?string $targetName = null, ?int $width = null, ?int $height = null, ?string $windowFeatures = null)
+    public function __construct(string $targetName = null, int $width = null, int $height = null, string $windowFeatures = null)
     {
         $this->target_name = $targetName ?? null;
         $this->width = $width ?? null;

--- a/src/LtiMessageLaunch.php
+++ b/src/LtiMessageLaunch.php
@@ -283,7 +283,7 @@ class LtiMessageLaunch
         return $this->launch_id;
     }
 
-    public static function getMissingRegistrationErrorMsg(string $issuerUrl, ?string $clientId = null): string
+    public static function getMissingRegistrationErrorMsg(string $issuerUrl, string $clientId = null): string
     {
         // Guard against client ID being null
         if (!isset($clientId)) {


### PR DESCRIPTION
## Summary of Changes

The `line_items/:line_item_id/results` endpoint can be paginated as well, so the current implementation of `getGrades()` potentially doesn't return all results. This problem is solved by calling `getAll` instead of `makeServiceRequest`.

## Testing

- [ ] I have added automated tests for my changes
- [x] I ran `composer test` before opening this PR
- [x] I ran `composer lint-fix` before opening this PR
