### PR TITLE
Allow LtiMessgageLaunch validation steps to be modified by tool providers

### DIFF
--- a/src/LtiMessageLaunch.php
+++ b/src/LtiMessageLaunch.php
@@ -373,7 +373,7 @@ class LtiMessageLaunch
         return $this;
     }
 
-    private function validateState()
+    protected function validateState()
     {
         // Check State for OIDC.
         if ($this->cookie->getCookie(LtiOidcLogin::COOKIE_PREFIX.$this->request['state']) !== $this->request['state']) {
@@ -384,7 +384,7 @@ class LtiMessageLaunch
         return $this;
     }
 
-    private function validateJwtFormat()
+    protected function validateJwtFormat()
     {
         $jwt = $this->request['id_token'] ?? null;
 
@@ -408,7 +408,7 @@ class LtiMessageLaunch
         return $this;
     }
 
-    private function validateNonce()
+    protected function validateNonce()
     {
         if (!isset($this->jwt['body']['nonce'])) {
             throw new LtiException(static::ERR_MISSING_NONCE);
@@ -420,7 +420,7 @@ class LtiMessageLaunch
         return $this;
     }
 
-    private function validateRegistration()
+    protected function validateRegistration()
     {
         // Find registration.
         $clientId = is_array($this->jwt['body']['aud']) ? $this->jwt['body']['aud'][0] : $this->jwt['body']['aud'];
@@ -440,7 +440,7 @@ class LtiMessageLaunch
         return $this;
     }
 
-    private function validateJwtSignature()
+    protected function validateJwtSignature()
     {
         if (!isset($this->jwt['header']['kid'])) {
             throw new LtiException(static::ERR_NO_KID);
@@ -461,7 +461,7 @@ class LtiMessageLaunch
         return $this;
     }
 
-    private function validateDeployment()
+    protected function validateDeployment()
     {
         if (!isset($this->jwt['body'][LtiConstants::DEPLOYMENT_ID])) {
             throw new LtiException(static::ERR_MISSING_DEPLOYEMENT_ID);
@@ -479,7 +479,7 @@ class LtiMessageLaunch
         return $this;
     }
 
-    private function validateMessage()
+    protected function validateMessage()
     {
         if (empty($this->jwt['body'][LtiConstants::MESSAGE_TYPE])) {
             // Unable to identify message type.


### PR DESCRIPTION
## Summary of Changes

Hi there. I represent GoReact, a large educational feedback tool. We are adding support for LTI 1.3 and have decided to use your library to help us. In implementing this, we want to make a few modifications that will help us with the validation phases, but unfortunately, all the validation methods in the `LtiMessageLaunch` class are private and therefore cannot be modified by a class that extends it. This change simply makes those private methods protected so an extending class can modify them. We would love to work with you guys and potentially even help support this library if you feel you need extra help. LTI is an important part of what we do so we will be actively interested in the success of this project.

## Testing

- [ ] I have added automated tests for my changes
- [ x] I ran `composer test` before opening this PR
- [ x] I ran `composer lint-fix` before opening this PR

Seeing as how all we are doing here is marking the methods protected, new tests are not really necessary. Let me know if you have concerns with this change.
