### PR TITLE
PODC-859: Add a Disclaimer to `LtiGrade::setCanvasExtension`

### DIFF
--- a/src/LtiGrade.php
+++ b/src/LtiGrade.php
@@ -154,8 +154,15 @@ class LtiGrade
         return $this->canvas_extension;
     }
 
-    // Custom Extension for Canvas.
-    // https://documentation.instructure.com/doc/api/score.html
+    /**
+     * Add custom extensions for Canvas.
+     *
+     * Disclaimer: You should only set this if your LMS is Canvas.
+     *             Some LMS (e.g. Schoology) include validation logic that will throw if there
+     *             is unexpected data. And, the type of LMS cannot simply be inferred by their URL.
+     *
+     * @see https://documentation.instructure.com/doc/api/score.html
+     */
     public function setCanvasExtension($value)
     {
         $this->canvas_extension = $value;


### PR DESCRIPTION
## Summary of Changes

It seems if you blindly attach extra metadata onto GBS requests, some LMS will bomb out during request validation. Since keeping track of the LMS type (i.e. determining when to include metadata) is an application-level concern, I'm just making note of a pitfall on the relevant function.

## Testing

_(Documentation-only change)_