### PR TITLE
Add gradesReleased to LtiLineItem

### DIFF
--- a/src/LtiLineitem.php
+++ b/src/LtiLineitem.php
@@ -12,6 +12,7 @@ class LtiLineitem
     private $tag;
     private $start_date_time;
     private $end_date_time;
+    private ?bool $grades_released;
 
     public function __construct(array $lineitem = null)
     {
@@ -23,6 +24,7 @@ class LtiLineitem
         $this->tag = $lineitem['tag'] ?? null;
         $this->start_date_time = $lineitem['startDateTime'] ?? null;
         $this->end_date_time = $lineitem['endDateTime'] ?? null;
+        $this->grades_released = $lineitem['gradesReleased'] ?? null;
     }
 
     public function __toString()
@@ -37,6 +39,7 @@ class LtiLineitem
             'tag' => $this->tag,
             'startDateTime' => $this->start_date_time,
             'endDateTime' => $this->end_date_time,
+            'gradesReleased' => $this->grades_released,
         ], '\Packback\Lti1p3\Helpers\Helpers::checkIfNullValue'));
     }
 
@@ -140,6 +143,18 @@ class LtiLineitem
     public function setEndDateTime($value)
     {
         $this->end_date_time = $value;
+
+        return $this;
+    }
+
+    public function getGradesReleased(): ?bool
+    {
+        return $this->grades_released;
+    }
+
+    public function setGradesReleased(?bool $value): self
+    {
+        $this->grades_released = $value;
 
         return $this;
     }

--- a/tests/LtiLineitemTest.php
+++ b/tests/LtiLineitemTest.php
@@ -6,6 +6,8 @@ use Packback\Lti1p3\LtiLineitem;
 
 class LtiLineitemTest extends TestCase
 {
+    private LtiLineitem $lineItem;
+
     public function setUp(): void
     {
         $this->lineItem = new LtiLineitem();
@@ -175,6 +177,41 @@ class LtiLineitemTest extends TestCase
         $this->assertEquals($expected, $this->lineItem->getEndDateTime());
     }
 
+    public function testItGetsGradesReleased(): void
+    {
+        $expected = true;
+        $grade = new LtiLineitem(['gradesReleased' => $expected]);
+
+        $result = $grade->getGradesReleased();
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testItSetsGradesReleased(): void
+    {
+        $expected = false;
+
+        $this->lineItem->setGradesReleased($expected);
+
+        $this->assertEquals($expected, $this->lineItem->getGradesReleased());
+    }
+
+    public function testGradesReleasedConstructedNullable(): void
+    {
+        $grade = new LtiLineitem();
+
+        $result = $grade->getGradesReleased();
+
+        $this->assertNull($result);
+    }
+
+    public function testGradesReleasedSetNullable(): void
+    {
+        $this->lineItem->setGradesReleased(null);
+
+        $this->assertNull($this->lineItem->getGradesReleased());
+    }
+
     public function testItCastsFullObjectToString()
     {
         $expected = [
@@ -186,6 +223,7 @@ class LtiLineitemTest extends TestCase
             'tag' => 'Tag',
             'startDateTime' => 'StartDateTime',
             'endDateTime' => 'EndDateTime',
+            'gradesReleased' => true,
         ];
 
         $lineItem = new LtiLineitem($expected);


### PR DESCRIPTION
## Summary of Changes

"gradesReleased" is a new feature of the [Assignment and Grade Services 2.0](https://www.imsglobal.org/spec/lti-ags/v2p0#gradesreleased) as of January 24th, 2023. This just adds the property to the line item model so that it may be retreived/set

## Testing

<!-- Describe how this PR has been tested, manually and automatically. -->

- [X] I have added automated tests for my changes
- [X] I ran `composer test` before opening this PR
- [X] I ran `composer lint-fix` before opening this PR
