### PR TITLE
Fix bug with authorization URLs having a query component

### DIFF
--- a/src/LtiOidcLogin.php
+++ b/src/LtiOidcLogin.php
@@ -90,7 +90,12 @@ class LtiOidcLogin
             $auth_params['lti_message_hint'] = $request['lti_message_hint'];
         }
 
-        $auth_login_return_url = $registration->getAuthLoginUrl().'?'.http_build_query($auth_params, '', '&');
+        if (parse_url($registration->getAuthLoginUrl(), PHP_URL_QUERY)) {
+            $separator = '&';
+        } else {
+            $separator = '?';
+        }
+        $auth_login_return_url = $registration->getAuthLoginUrl().$separator.http_build_query($auth_params, '', '&');
 
         // Return auth redirect.
         return new Redirect($auth_login_return_url, http_build_query($request, '', '&'));


### PR DESCRIPTION
As per RFC6749, section 3.1, the auth URL may have a query string. E.g. 'https://example.com/oidc?auth'. So, don't assume that '?' will be the separator when generating the auth URL.

## Summary of changes

This change ensures that LtiOidcLogin::doOidcLoginRedirect() creates the auth URL properly in cases where the platform's auth URL contains a query component, and where '?' will already be present in the URL.

Prior to this change, an auth URL like 'https://example.com/oidc?auth' would result in the code generating something like:
'https://example.com/odic?auth?other=1&params=2&here=3' (note the 2x '?').

## Testing

I've tested this one manually by adding some query params to the saved auth URL for a test platform and performing a launch. Without the change, there's a problem finding the scope because of the query params and the launch fails.

- [ N] I have added automated tests for my changes
- [ Y] I ran `composer test` before opening this PR
- [ Y] I ran `composer lint-fix` before opening this PR
