### PR TITLE
Add src field to iframe resource

### DIFF
--- a/src/LtiDeepLinkResourceIframe.php
+++ b/src/LtiDeepLinkResourceIframe.php
@@ -6,11 +6,13 @@ class LtiDeepLinkResourceIframe
 {
     private ?int $width;
     private ?int $height;
+    private ?string $src;
 
-    public function __construct(int $width = null, int $height = null)
+    public function __construct(int $width = null, int $height = null, string $src = null)
     {
         $this->width = $width ?? null;
         $this->height = $height ?? null;
+        $this->src = $src ?? null;
     }
 
     public static function new(): LtiDeepLinkResourceIframe
@@ -42,6 +44,18 @@ class LtiDeepLinkResourceIframe
         return $this->height;
     }
 
+    public function setSrc(?string $src): LtiDeepLinkResourceIframe
+    {
+        $this->src = $src;
+
+        return $this;
+    }
+    
+    public function getSrc(): ?string
+    {
+        return $this->src;
+    }
+
     public function toArray(): array
     {
         $iframe = [];
@@ -51,6 +65,9 @@ class LtiDeepLinkResourceIframe
         }
         if (isset($this->height)) {
             $iframe['height'] = $this->height;
+        }
+        if (isset($this->src)) {
+            $iframe['src'] = $this->src;
         }
 
         return $iframe;

--- a/src/LtiDeepLinkResourceIframe.php
+++ b/src/LtiDeepLinkResourceIframe.php
@@ -50,7 +50,7 @@ class LtiDeepLinkResourceIframe
 
         return $this;
     }
-    
+
     public function getSrc(): ?string
     {
         return $this->src;

--- a/tests/LtiDeepLinkResourceIframeTest.php
+++ b/tests/LtiDeepLinkResourceIframeTest.php
@@ -94,7 +94,7 @@ class LtiDeepLinkResourceIframeTest extends TestCase
         $expected = [
             'width' => 100,
             'height' => 200,
-            'src' => 'https://example.com'
+            'src' => 'https://example.com',
         ];
 
         $this->ltiDeepLinkResourceIframe->setWidth($expected['width']);

--- a/tests/LtiDeepLinkResourceIframeTest.php
+++ b/tests/LtiDeepLinkResourceIframeTest.php
@@ -61,10 +61,28 @@ class LtiDeepLinkResourceIframeTest extends TestCase
         $this->assertEquals($expected, $this->ltiDeepLinkResourceIframe->getHeight());
     }
 
+    public function testItGetsSrc()
+    {
+        $result = $this->ltiDeepLinkResourceIframe->getSrc();
+
+        $this->assertNull($result);
+    }
+
+    public function testItSetsSrc()
+    {
+        $expected = 'https://example.com';
+
+        $result = $this->ltiDeepLinkResourceIframe->setSrc($expected);
+
+        $this->assertSame($this->ltiDeepLinkResourceIframe, $result);
+        $this->assertEquals($expected, $this->ltiDeepLinkResourceIframe->getSrc());
+    }
+
     public function testItCreatesArrayWithoutOptionalProperties()
     {
         $this->ltiDeepLinkResourceIframe->setWidth(null);
         $this->ltiDeepLinkResourceIframe->setHeight(null);
+        $this->ltiDeepLinkResourceIframe->setSrc(null);
 
         $result = $this->ltiDeepLinkResourceIframe->toArray();
 
@@ -76,10 +94,12 @@ class LtiDeepLinkResourceIframeTest extends TestCase
         $expected = [
             'width' => 100,
             'height' => 200,
+            'src' => 'https://example.com'
         ];
 
         $this->ltiDeepLinkResourceIframe->setWidth($expected['width']);
         $this->ltiDeepLinkResourceIframe->setHeight($expected['height']);
+        $this->ltiDeepLinkResourceIframe->setSrc($expected['src']);
 
         $result = $this->ltiDeepLinkResourceIframe->toArray();
 


### PR DESCRIPTION
## Summary of Changes

Discussed in #108, Canvas expects a `src` parameter on iframe deeplink resources. Even if the URL of the deeplink is set, nothing will be rendered if `src` is not present. This PR adds the `src` parameter to the existing `height` and `width` values. 

## Testing

Tests were added. I also ran this in a dev instance against Canvas to verify the functionality is behaving as expected. 

- [x] I have added automated tests for my changes
- [x] I ran `composer test` before opening this PR
- [x] I ran `composer lint-fix` before opening this PR
