### PR TITLE
Adding options to getMembers

### DIFF
--- a/src/LtiNamesRolesProvisioningService.php
+++ b/src/LtiNamesRolesProvisioningService.php
@@ -11,11 +11,18 @@ class LtiNamesRolesProvisioningService extends LtiAbstractService
         return [LtiConstants::NRPS_SCOPE_MEMBERSHIP_READONLY];
     }
 
-    public function getMembers(): array
+    /**
+     * @param  array  $options An array of options that can be passed with the context_membership_url such as rlid, since, etc.
+     */
+    public function getMembers(array $options = []): array
     {
+        $url = $this->getServiceData()['context_memberships_url'];
+        if (!empty($options)) {
+            $url .= '?'.http_build_query($options);
+        }
         $request = new ServiceRequest(
             ServiceRequest::METHOD_GET,
-            $this->getServiceData()['context_memberships_url'],
+            $url,
             ServiceRequest::TYPE_GET_MEMBERSHIPS
         );
         $request->setAccept(static::CONTENTTYPE_MEMBERSHIPCONTAINER);

--- a/tests/LtiNamesRolesProvisioningServiceTest.php
+++ b/tests/LtiNamesRolesProvisioningServiceTest.php
@@ -36,4 +36,22 @@ class LtiNamesRolesProvisioningServiceTest extends TestCase
 
         $this->assertEquals($expected, $result);
     }
+
+    public function testItGetsMembersForResourceLink()
+    {
+        $expected = ['members'];
+
+        $nrps = new LtiNamesRolesProvisioningService($this->connector, $this->registration, [
+            'context_memberships_url' => 'url',
+        ]);
+        $this->connector->shouldReceive('getAll')
+            ->withArgs(function ($registration, $scope, $request, $key) {
+                return $request->getUrl() === 'url?rlid=resource-link-id' && $key === 'members';
+            })
+            ->once()->andReturn($expected);
+
+        $result = $nrps->getMembers(['rlid' => 'resource-link-id']);
+
+        $this->assertEquals($expected, $result);
+    }
 }


### PR DESCRIPTION
## Summary of Changes

This is adding the ability to send an array of options such as `rlid` or `since` to the getMembers method in order to support other optional ways of getting member information that are supported in the spec as seen [here](https://www.imsglobal.org/spec/lti-nrps/v2p0#resource-link-membership-service).

## Testing

- [x] I have added automated tests for my changes
- [x] I ran `composer test` before opening this PR
- [x] I ran `composer lint-fix` before opening this PR
