### PR TITLE
Add the ability to mask log data

### DIFF
--- a/src/ServiceRequest.php
+++ b/src/ServiceRequest.php
@@ -43,6 +43,9 @@ class ServiceRequest implements IServiceRequest
     private $contentType = 'application/json';
     private $accept = 'application/json';
 
+    // Other
+    private $maskResponseLogs = false;
+
     public function __construct(string $method, string $url, $type = self::UNSUPPORTED)
     {
         $this->method = $method;
@@ -116,6 +119,18 @@ class ServiceRequest implements IServiceRequest
     public function setContentType(string $contentType): IServiceRequest
     {
         $this->contentType = $contentType;
+
+        return $this;
+    }
+
+    public function getMaskResponseLogs(): bool
+    {
+        return $this->maskResponseLogs;
+    }
+
+    public function setMaskResponseLogs(bool $shouldMask): IServiceRequest
+    {
+        $this->maskResponseLogs = $shouldMask;
 
         return $this;
     }

--- a/tests/LtiServiceConnectorTest.php
+++ b/tests/LtiServiceConnectorTest.php
@@ -330,6 +330,36 @@ class LtiServiceConnectorTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
+    public function testItBuildsLogMessage()
+    {
+        $this->mockMakeRequest();
+        $this->request->shouldReceive('getErrorPrefix')
+            ->once()->andReturn('Logging request data:');
+        $this->request->shouldReceive('getMaskResponseLogs')
+            ->once()->andReturn(false);
+
+        $result = $this->connector::getLogMessage($this->request, ['foo' => 'bar'], ['baz' => 'bat']);
+
+        $expected = "Logging request data: id Array\n(\n    [request_method] => POST\n    [request_url] => https://example.com\n    [response_headers] => Array\n        (\n            [foo] => bar\n        )\n\n    [response_body] => {\"baz\":\"bat\"}\n    [request_body] => {\"userId\":\"id\"}\n)\n";
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testItMasksSensitiveDataInLogMessage()
+    {
+        $this->mockMakeRequest();
+        $this->request->shouldReceive('getErrorPrefix')
+            ->once()->andReturn('Logging request data:');
+        $this->request->shouldReceive('getMaskResponseLogs')
+            ->once()->andReturn(true);
+
+        $result = $this->connector::getLogMessage($this->request, ['foo' => 'bar'], ['baz' => 'bat']);
+
+        $expected = "Logging request data: id Array\n(\n    [request_method] => POST\n    [request_url] => https://example.com\n    [response_headers] => Array\n        (\n            [foo] => ***\n        )\n\n    [response_body] => {\"baz\":\"***\"}\n    [request_body] => {\"userId\":\"id\"}\n)\n";
+
+        $this->assertEquals($expected, $result);
+    }
+
     private function mockMakeRequest()
     {
         // It makes another request


### PR DESCRIPTION
## Summary of Changes

Mask auth data in requests

## Testing

<!-- Describe how this PR has been tested, manually and automatically. -->

- [x] I have added automated tests for my changes
- [x] I ran `composer test` before opening this PR
- [x] I ran `composer lint-fix` before opening this PR
