### PR TITLE
Json encode log objects instead of printing a multiline string

### DIFF
--- a/src/LtiServiceConnector.php
+++ b/src/LtiServiceConnector.php
@@ -204,7 +204,7 @@ class LtiServiceConnector implements ILtiServiceConnector
         return implode(' ', array_filter([
             $request->getErrorPrefix(),
             json_decode($requestBody)->userId ?? null,
-            print_r($contextArray, true),
+            json_encode($contextArray),
         ]));
     }
 

--- a/tests/LtiServiceConnectorTest.php
+++ b/tests/LtiServiceConnectorTest.php
@@ -340,7 +340,7 @@ class LtiServiceConnectorTest extends TestCase
 
         $result = $this->connector::getLogMessage($this->request, ['foo' => 'bar'], ['baz' => 'bat']);
 
-        $expected = "Logging request data: id Array\n(\n    [request_method] => POST\n    [request_url] => https://example.com\n    [response_headers] => Array\n        (\n            [foo] => bar\n        )\n\n    [response_body] => {\"baz\":\"bat\"}\n    [request_body] => {\"userId\":\"id\"}\n)\n";
+        $expected = "Logging request data: id {\"request_method\":\"POST\",\"request_url\":\"https:\/\/example.com\",\"response_headers\":{\"foo\":\"bar\"},\"response_body\":\"{\\\"baz\\\":\\\"bat\\\"}\",\"request_body\":\"{\\\"userId\\\":\\\"id\\\"}\"}";
 
         $this->assertEquals($expected, $result);
     }
@@ -355,7 +355,7 @@ class LtiServiceConnectorTest extends TestCase
 
         $result = $this->connector::getLogMessage($this->request, ['foo' => 'bar'], ['baz' => 'bat']);
 
-        $expected = "Logging request data: id Array\n(\n    [request_method] => POST\n    [request_url] => https://example.com\n    [response_headers] => Array\n        (\n            [foo] => ***\n        )\n\n    [response_body] => {\"baz\":\"***\"}\n    [request_body] => {\"userId\":\"id\"}\n)\n";
+        $expected = "Logging request data: id {\"request_method\":\"POST\",\"request_url\":\"https:\/\/example.com\",\"response_headers\":{\"foo\":\"***\"},\"response_body\":\"{\\\"baz\\\":\\\"***\\\"}\",\"request_body\":\"{\\\"userId\\\":\\\"id\\\"}\"}";
 
         $this->assertEquals($expected, $result);
     }


### PR DESCRIPTION
## Summary of Changes

Currently when we log requests, it's spits out a nasty multi-line logs for the response object that are impossible to read in stackdriver. Example:

```
[28-Nov-2023 15:13:42 UTC] Getting lineitems: Array
(
    [request_method] => GET
    [request_url] => https://canvas.localhost/api/lti/courses/13/line_items
    [response_headers] => Array
        (
            [Server] => nginx/1.25.2
            [Date] => Tue, 28 Nov 2023 15:13:42 GMT
            [Content-Type] => application/vnd.ims.lis.v2.lineitemcontainer+json; charset=utf-8
            [Transfer-Encoding] => chunked
            [Connection] => keep-alive
            [Status] => 200 OK
            [X-Request-Cost] => 0.06348237000029755
            [Cache-Control] => max-age=0, private, must-revalidate
            [X-Request-Context-Id] => 0ba25001-7296-4114-985d-12ced8ef7d53
            [Strict-Transport-Security] => max-age=31536000
            [Referrer-Policy] => no-referrer-when-downgrade
            [X-Rate-Limit-Remaining] => 600.0
            [X-Permitted-Cross-Domain-Policies] => none
        )
)
```

This changes it to json-encode the object, which is more developer friendly and puts everything on a single line. Here's the result:

```
[28-Nov-2023 15:13:42 UTC] Getting lineitems: { "request_method": "GET", "request_url": "https://canvas.localhost/api/lti/courses/13/line_items", "response_headers": { "Server": "nginx/1.25.2", "Date": "Tue, 28 Nov 2023 15:13:42 GMT", "Content-Type": "application/vnd.ims.lis.v2.lineitemcontainer+json; charset=utf-8", "Transfer-Encoding": "chunked", "Connection": "keep-alive", "Status": "200 OK", "X-Request-Cost": "0.06348237000029755", "Cache-Control": "max-age=0, private, must-revalidate", "X-Request-Context-Id": "0ba25001-7296-4114-985d-12ced8ef7d53", "Strict-Transport-Security": "max-age=31536000", "Referrer-Policy": "no-referrer-when-downgrade", "X-Rate-Limit-Remaining": "600.0", "X-Permitted-Cross-Domain-Policies": "none" }}
```

## Testing

<!-- Describe how this PR has been tested, manually and automatically. -->

- [x] I have added automated tests for my changes
- [x] I ran `composer test` before opening this PR
- [x] I ran `composer lint-fix` before opening this PR
