### PR TITLE
Add PHP version requirement to composer.json

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         php:
-          - "8.0"
+          - "8.1"
           - "latest"
     steps:
       - uses: "actions/checkout@v3"

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         }
     ],
     "require": {
+        "php": "^8.0",
         "firebase/php-jwt": "^6.6",
         "guzzlehttp/guzzle": "^7.0",
         "phpseclib/phpseclib": "^3.0"

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "firebase/php-jwt": "^6.6",
         "guzzlehttp/guzzle": "^7.0",
         "phpseclib/phpseclib": "^3.0"


### PR DESCRIPTION
## Summary of Changes

The recently released version 6 contains changes that are only available since PHP 8.1, like initializing class variables in the constructor (see [this RFC](https://wiki.php.net/rfc/new_in_initializers) ). The code example below is from **LtiMessageLaunch**:
````
    public function __construct(
        private IDatabase $db,
        private ICache $cache,
        private ICookie $cookie,
        private ILtiServiceConnector $serviceConnector
    ) {
        $this->launch_id = uniqid('lti1p3_launch_', true);
    }
````

Having a php version designated in the `composer.json` throws an error if someone with an out-of-date php version attempts to require the package, providing an early warning that they wouldn't be able to use it due to the newer language constructs implemented.

## Testing

<!-- Describe how this PR has been tested, manually and automatically. -->

- [ ] I have added automated tests for my changes - N/A
- [ ] I ran `composer test` before opening this PR - N/A
- [ ] I ran `composer lint-fix` before opening this PR - N/A
