### PR TITLE
Pass the previous exception

### DIFF
--- a/src/LtiMessageLaunch.php
+++ b/src/LtiMessageLaunch.php
@@ -304,7 +304,7 @@ class LtiMessageLaunch
         try {
             $response = $this->serviceConnector->makeRequest($request);
         } catch (TransferException $e) {
-            throw new LtiException(static::ERR_NO_PUBLIC_KEY);
+            throw new LtiException(static::ERR_NO_PUBLIC_KEY, previous: $e);
         }
         $publicKeySet = $this->serviceConnector->getResponseBody($response);
 
@@ -442,7 +442,7 @@ class LtiMessageLaunch
             JWT::decode($this->request['id_token'], $public_key, $headers);
         } catch (ExpiredException $e) {
             // Error validating signature.
-            throw new LtiException(static::ERR_INVALID_SIGNATURE);
+            throw new LtiException(static::ERR_INVALID_SIGNATURE, previous: $e);
         }
 
         return $this;


### PR DESCRIPTION
## Summary of Changes

When throwing an `LtiException` inside a try-catch, pass along the previous exception with it.

This is in response to https://github.com/packbackbooks/lti-1-3-php-library/issues/145

## Testing

<!-- Describe how this PR has been tested, manually and automatically. -->

- [x] I have added automated tests for my changes
- [x] I ran `composer test` before opening this PR
- [x] I ran `composer lint-fix` before opening this PR

Here are these changes in our platform: https://gitlab.com/packback/questions/-/pipelines/1380815824
