### PR TITLE
ENG-3903: add error handling for missing target uri

### DIFF
--- a/src/LtiOidcLogin.php
+++ b/src/LtiOidcLogin.php
@@ -14,6 +14,7 @@ class LtiOidcLogin
     public const ERROR_MSG_LAUNCH_URL = 'No launch URL configured';
     public const ERROR_MSG_ISSUER = 'Could not find issuer';
     public const ERROR_MSG_LOGIN_HINT = 'Could not find login hint';
+    public const ERROR_MSG_TARGET_LINK = 'Could not find target link';
 
     public function __construct(
         public IDatabase $db,
@@ -51,6 +52,10 @@ class LtiOidcLogin
 
         if (!isset($request['login_hint'])) {
             throw new OidcException(static::ERROR_MSG_LOGIN_HINT);
+        }
+
+        if (!isset($request['target_link_uri'])) {
+            throw new OidcException(static::ERROR_MSG_TARGET_LINK);
         }
 
         // Fetch registration

--- a/src/MessageValidators/ResourceMessageValidator.php
+++ b/src/MessageValidators/ResourceMessageValidator.php
@@ -22,5 +22,9 @@ class ResourceMessageValidator extends AbstractMessageValidator
         if (empty($jwtBody[LtiConstants::RESOURCE_LINK]['id'])) {
             throw new LtiException('Missing Resource Link Id');
         }
+        
+        if (empty($jwtBody[LtiConstants::TARGET_LINK_URI])) {
+            throw new LtiException('Missing Target Link URI');
+        }
     }
 }

--- a/tests/MessageValidators/ResourceMessageValidatorTest.php
+++ b/tests/MessageValidators/ResourceMessageValidatorTest.php
@@ -76,6 +76,16 @@ class ResourceMessageValidatorTest extends TestCase
 
         ResourceMessageValidator::validate($jwtBody);
     }
+    
+    public function testJwtBodyIsInvalidMissingTargetLinkUri()
+    {
+        $jwtBody = self::validJwtBody();
+        unset($jwtBody[LtiConstants::TARGET_LINK_URI]);
+
+        $this->expectException(LtiException::class);
+
+        ResourceMessageValidator::validate($jwtBody);
+    }
 
     private static function validJwtBody()
     {
@@ -87,6 +97,7 @@ class ResourceMessageValidatorTest extends TestCase
             LtiConstants::RESOURCE_LINK => [
                 'id' => 'unique-id',
             ],
+            LtiConstants::TARGET_LINK_URI => 'https://example.com/launch',
         ];
     }
 }


### PR DESCRIPTION
 Add validation for target_link_uri in LTI resource messages

  Purpose

  This PR adds validation for the required target_link_uri claim in LTI Resource Link Requests, improving message security and conformance to the LTI 1.3 specification.

  Importance

  The target_link_uri is a required claim in LTI 1.3 resource link launches that specifies the intended destination URI for the launch. Validating this field:
  - Prevents processing incomplete/malformed LTI messages
  - Ensures proper implementation of security measures according to the specification
  - Protects applications from launch requests that might attempt to bypass launch target validation

  Implementation

  - Added validation in ResourceMessageValidator::validate() that checks for the presence of the target_link_uri claim
  - Added corresponding test case in ResourceMessageValidatorTest to verify the validation behavior
  - Uses existing exception handling patterns consistent with other validations

  Standards Reference

  This change ensures conformance with the IMS Global LTI 1.3 Core Specification which requires the https://purl.imsglobal.org/spec/lti/claim/target_link_uri claim for all resource link
  launch messages.


## Testing

<!-- Describe how this PR has been tested, manually and automatically. -->

- [ ] I have added automated tests for my changes
- [ ] I ran `composer test` before opening this PR
- [ ] I ran `composer lint-fix` before opening this PR
