### PR TITLE
ENG-4213: remove the iframe target from DL resource

### DIFF
--- a/src/DeepLinkResources/Resource.php
+++ b/src/DeepLinkResources/Resource.php
@@ -56,13 +56,6 @@ class Resource
             ];
         }
 
-        // Kept for backwards compatibility
-        if (!isset($this->iframe) && !isset($this->window)) {
-            $resource['presentation'] = [
-                'documentTarget' => $this->target,
-            ];
-        }
-
         return $resource;
     }
 

--- a/tests/DeepLinkResources/ResourceTest.php
+++ b/tests/DeepLinkResources/ResourceTest.php
@@ -237,20 +237,6 @@ class ResourceTest extends TestCase
         $this->assertEquals($expected, $this->resource->getSubmissionInterval());
     }
 
-    public function testItCreatesArrayWithoutOptionalProperties()
-    {
-        $expected = [
-            'type' => LtiConstants::DL_RESOURCE_LINK_TYPE,
-            'presentation' => [
-                'documentTarget' => 'iframe',
-            ],
-        ];
-
-        $result = $this->resource->toArray();
-
-        $this->assertEquals($expected, $result);
-    }
-
     public function testItCreatesArrayWithDefinedOptionalProperties()
     {
         $icon = Icon::new('https://example.com/image.png', 100, 200);


### PR DESCRIPTION
## Summary of Changes

This field isn't valid per 1edtech cert specs (lol... at least that's what they say). Tests still pass. 
![image](https://github.com/user-attachments/assets/123def70-929e-469d-afed-9e9cccd6a114)


## Testing

<!-- Describe how this PR has been tested, manually and automatically. -->

- [ ] I have added automated tests for my changes
- [ ] I ran `composer test` before opening this PR
- [ ] I ran `composer lint-fix` before opening this PR
