### PR TITLE
Add user ID filter to grades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ vendor
 # ignore the coverage folders
 **/.phpunit.cache
 **/coverage
+
+**/.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,24 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build/Test/Lint Commands
+- Run all tests: `composer test`
+- Run a single test: `vendor/bin/phpunit tests/path/to/TestFile.php --filter testMethodName`
+- Run static analysis: `vendor/bin/phpstan analyse`
+- Check code style: `composer lint`
+- Fix code style issues: `composer lint-fix`
+
+## Code Style Guidelines
+- Follow PSR-1/PSR-2 coding standards (Laravel preset)
+- Use PHP 8.1+ features and type hints
+- Classes organized in the namespace `Packback\Lti1p3`
+- Tests in the namespace `Tests`
+- Document public methods with PHPDoc blocks
+- Constants for error messages (use const ERR_* pattern)
+- Use interfaces for dependency injection
+- Error handling: Throw exceptions with descriptive messages
+- Import all classes with use statements
+- Use strict type checking (avoid loose comparisons)
+- Use camelCase for method names and variables
+- Line length: 80-120 characters

--- a/tests/LtiAssignmentsGradesServiceTest.php
+++ b/tests/LtiAssignmentsGradesServiceTest.php
@@ -480,4 +480,38 @@ class LtiAssignmentsGradesServiceTest extends TestCase
 
         $this->assertEquals($expected, $result);
     }
+
+    public function test_it_appends_path()
+    {
+        // A simple example
+        $lineItem = new LtiLineitem(['id' => 'https://example.com']);
+
+        $result = LtiAssignmentsGradesService::appendLineItemPath($lineItem, '/bat');
+
+        $this->assertEquals('https://example.com/bat', $result);
+
+        // A complicated example
+        $lineItem = new LtiLineitem(['id' => 'https://example.com:443/foo?bar=baz']);
+
+        $result = LtiAssignmentsGradesService::appendLineItemPath($lineItem, '/bat');
+
+        $this->assertEquals('https://example.com:443/foo/bat?bar=baz', $result);
+    }
+
+    public function test_it_query_params()
+    {
+        // A simple example
+        $url = 'https://example.com';
+
+        $result = LtiAssignmentsGradesService::appendQueryParams($url, ['user_id' => 'foo']);
+
+        $this->assertEquals('https://example.com?user_id=foo', $result);
+
+        // A complicated example
+        $url = 'https://example.com:443/foo?bar=baz';
+
+        $result = LtiAssignmentsGradesService::appendQueryParams($url, ['user_id' => 'foo']);
+
+        $this->assertEquals('https://example.com:443/foo?bar=baz&user_id=foo', $result);
+    }
 }


### PR DESCRIPTION
## Summary of Changes

See: https://github.com/packbackbooks/lti-1-3-php-library/issues/159

## Testing

- [x] I have added automated tests for my changes
- [x] I ran `composer test` before opening this PR
- [x] I ran `composer lint-fix` before opening this PR
