### PR TITLE
ENG-4471: Allow DateTimeInterval to have `null` start and end

### DIFF
--- a/src/DeepLinkResources/DateTimeInterval.php
+++ b/src/DeepLinkResources/DateTimeInterval.php
@@ -9,7 +9,6 @@ use Packback\Lti1p3\LtiException;
 class DateTimeInterval
 {
     use Arrayable;
-    public const ERROR_NO_START_OR_END = 'Either a start or end time must be specified.';
     public const ERROR_START_GT_END = 'The start time cannot be greater than end time.';
 
     public function __construct(

--- a/src/DeepLinkResources/DateTimeInterval.php
+++ b/src/DeepLinkResources/DateTimeInterval.php
@@ -26,15 +26,15 @@ class DateTimeInterval
 
     public function getArray(): array
     {
-        if (!isset($this->start) && !isset($this->end)) {
-            throw new LtiException(self::ERROR_NO_START_OR_END);
-        }
+        // if (!isset($this->start) && !isset($this->end)) {
+        //     throw new LtiException(self::ERROR_NO_START_OR_END);
+        // }
 
         $this->validateStartAndEnd();
 
         return [
-            'startDateTime' => $this->start?->format(DateTime::ATOM),
-            'endDateTime' => $this->end?->format(DateTime::ATOM),
+            'startDateTime' => $this->start?->format(DateTime::ATOM) ?? null,
+            'endDateTime' => $this->end?->format(DateTime::ATOM) ?? null,
         ];
     }
 
@@ -67,7 +67,7 @@ class DateTimeInterval
      */
     private function validateStartAndEnd(): void
     {
-        if (isset($this->start) && isset($this->end) && $this->start > $this->end) {
+        if ($this->start > $this->end) {
             throw new LtiException(self::ERROR_START_GT_END);
         }
     }

--- a/src/DeepLinkResources/DateTimeInterval.php
+++ b/src/DeepLinkResources/DateTimeInterval.php
@@ -26,10 +26,6 @@ class DateTimeInterval
 
     public function getArray(): array
     {
-        // if (!isset($this->start) && !isset($this->end)) {
-        //     throw new LtiException(self::ERROR_NO_START_OR_END);
-        // }
-
         $this->validateStartAndEnd();
 
         return [

--- a/src/DeepLinkResources/DateTimeInterval.php
+++ b/src/DeepLinkResources/DateTimeInterval.php
@@ -67,7 +67,7 @@ class DateTimeInterval
      */
     private function validateStartAndEnd(): void
     {
-        if ($this->start > $this->end) {
+        if (isset($this->start) && isset($this->end) && $this->start > $this->end) {
             throw new LtiException(self::ERROR_START_GT_END);
         }
     }

--- a/tests/DeepLinkResources/DateTimeIntervalTest.php
+++ b/tests/DeepLinkResources/DateTimeIntervalTest.php
@@ -32,6 +32,35 @@ class DateTimeIntervalTest extends TestCase
         $this->assertInstanceOf(DateTimeInterval::class, $DeepLinkResources);
     }
 
+    public function test_it_instantiates_with_null_start_end_values()
+    {
+        $dateTimeInterval = new DateTimeInterval(null, null);
+
+        $this->assertInstanceOf(DateTimeInterval::class, $dateTimeInterval);
+        $this->assertNull($dateTimeInterval->getStart());
+        $this->assertNull($dateTimeInterval->getEnd());
+    }
+
+    public function test_it_instantiates_with_null_start()
+    {
+        $end = date_create('+1 day');
+        $dateTimeInterval = new DateTimeInterval(null, $end);
+
+        $this->assertInstanceOf(DateTimeInterval::class, $dateTimeInterval);
+        $this->assertNull($dateTimeInterval->getStart());
+        $this->assertEquals($end, $dateTimeInterval->getEnd());
+    }
+
+    public function test_it_instantiates_with_null_end()
+    {
+        $start = date_create();
+        $dateTimeInterval = new DateTimeInterval($start, null);
+
+        $this->assertInstanceOf(DateTimeInterval::class, $dateTimeInterval);
+        $this->assertEquals($start, $dateTimeInterval->getStart());
+        $this->assertNull($dateTimeInterval->getEnd());
+    }
+
     public function test_it_gets_start()
     {
         $result = $this->dateTimeInterval->getStart();
@@ -66,15 +95,62 @@ class DateTimeIntervalTest extends TestCase
         $this->assertEquals($expected, $this->dateTimeInterval->getEnd());
     }
 
-    public function test_it_throws_exception_when_creating_array_with_both_properties_null()
+    public function test_it_sets_start_to_null()
     {
+        $result = $this->dateTimeInterval->setStart(null);
+
+        $this->assertSame($this->dateTimeInterval, $result);
+        $this->assertNull($this->dateTimeInterval->getStart());
+    }
+
+    public function test_it_sets_end_to_null()
+    {
+        $result = $this->dateTimeInterval->setEnd(null);
+
+        $this->assertSame($this->dateTimeInterval, $result);
+        $this->assertNull($this->dateTimeInterval->getEnd());
+    }
+
+    public function test_it_creates_array_with_null_start()
+    {
+        $expectedEnd = date_create('+1 day');
+        $expected = [
+            'endDateTime' => $expectedEnd->format(DateTime::ATOM),
+        ];
+
+        $this->dateTimeInterval->setStart(null);
+        $this->dateTimeInterval->setEnd($expectedEnd);
+
+        $result = $this->dateTimeInterval->toArray();
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function test_it_creates_array_with_null_end()
+    {
+        $expectedStart = date_create('+1 day');
+        $expected = [
+            'startDateTime' => $expectedStart->format(DateTime::ATOM),
+        ];
+
+        $this->dateTimeInterval->setStart($expectedStart);
+        $this->dateTimeInterval->setEnd(null);
+
+        $result = $this->dateTimeInterval->toArray();
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function test_it_creates_array_with_both_null()
+    {
+        $expected = [];
+
         $this->dateTimeInterval->setStart(null);
         $this->dateTimeInterval->setEnd(null);
 
-        $this->expectException(LtiException::class);
-        $this->expectExceptionMessage(DateTimeInterval::ERROR_NO_START_OR_END);
+        $result = $this->dateTimeInterval->toArray();
 
-        $this->dateTimeInterval->toArray();
+        $this->assertEquals($expected, $result);
     }
 
     public function test_it_throws_exception_when_creating_array_with_invalid_time_interval()

--- a/tests/DeepLinkResources/ResourceTest.php
+++ b/tests/DeepLinkResources/ResourceTest.php
@@ -263,7 +263,7 @@ class ResourceTest extends TestCase
             ],
             'submission' => [
                 'endDateTime' => $submissionInterval->getEnd()->format(\DateTime::ATOM),
-            ]
+            ],
         ];
 
         $this->resource->setAvailabilityInterval($availabilityInterval);

--- a/tests/DeepLinkResources/ResourceTest.php
+++ b/tests/DeepLinkResources/ResourceTest.php
@@ -237,6 +237,43 @@ class ResourceTest extends TestCase
         $this->assertEquals($expected, $this->resource->getSubmissionInterval());
     }
 
+    public function test_it_creates_array_with_null_date_time_intervals()
+    {
+        $expected = [
+            'type' => LtiConstants::DL_RESOURCE_LINK_TYPE,
+        ];
+
+        $this->resource->setAvailabilityInterval(null);
+        $this->resource->setSubmissionInterval(null);
+
+        $result = $this->resource->toArray();
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function test_it_creates_array_with_date_time_intervals_having_null_dates()
+    {
+        $availabilityInterval = new DateTimeInterval(date_create(), null);
+        $submissionInterval = new DateTimeInterval(null, date_create());
+
+        $expected = [
+            'type' => LtiConstants::DL_RESOURCE_LINK_TYPE,
+            'available' => [
+                'startDateTime' => $availabilityInterval->getStart()->format(\DateTime::ATOM),
+            ],
+            'submission' => [
+                'endDateTime' => $submissionInterval->getEnd()->format(\DateTime::ATOM),
+            ]
+        ];
+
+        $this->resource->setAvailabilityInterval($availabilityInterval);
+        $this->resource->setSubmissionInterval($submissionInterval);
+
+        $result = $this->resource->toArray();
+
+        $this->assertEquals($expected, $result);
+    }
+
     public function test_it_creates_array_with_defined_optional_properties()
     {
         $icon = Icon::new('https://example.com/image.png', 100, 200);


### PR DESCRIPTION
## Summary of Changes

<!-- A few sentences describing the big picture of your changes. -->

From the spec ResourceLink.(available/submission).(startDateTime/endDateTime) are both optional fields and do not need to both be present for the Resource Link to work.

https://www.imsglobal.org/spec/lti-dl/v2p0#lti-resource-link


<details>
<summary>`composer test` results</summary>

<img width="421" alt="Screenshot 2025-06-10 at 5 00 16 PM" src="https://github.com/user-attachments/assets/3753cf23-0807-490f-ac85-c1fc5b1a0197" />



</details>




<details>
<summary>`composer lint-fix` results</summary>

<img width="1370" alt="Screenshot 2025-06-10 at 4 30 22 PM" src="https://github.com/user-attachments/assets/e0366267-bf9e-4aec-a92a-5ec287497ca7" />


</details>

## Testing

<!-- Describe how this PR has been tested, manually and automatically. -->

- [x] I have added automated tests for my changes
- [x] I ran `composer test` before opening this PR
- [x] I ran `composer lint-fix` before opening this PR
